### PR TITLE
fix: error handling and http methods

### DIFF
--- a/http.go
+++ b/http.go
@@ -34,7 +34,7 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 	err = retry.Do(func() error {
 		resp, err = c.http.Do(req)
 		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.Login(); err != nil {
+			if err := c.LoginCtx(ctx); err != nil {
 				return errors.Wrap(err, "qbit re-login failed")
 			}
 		} else if err != nil {
@@ -83,7 +83,7 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	err = retry.Do(func() error {
 		resp, err = c.http.Do(req)
 		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.Login(); err != nil {
+			if err := c.LoginCtx(ctx); err != nil {
 				return errors.Wrap(err, "qbit re-login failed")
 			}
 		} else if err != nil {
@@ -196,7 +196,7 @@ func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName stri
 	err = retry.Do(func() error {
 		resp, err = c.http.Do(req)
 		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.Login(); err != nil {
+			if err := c.LoginCtx(ctx); err != nil {
 				return errors.Wrap(err, "qbit re-login failed")
 			}
 		} else if err != nil {

--- a/http.go
+++ b/http.go
@@ -15,11 +15,6 @@ import (
 	"github.com/avast/retry-go"
 )
 
-func (c *Client) get(endpoint string, opts map[string]string) (*http.Response, error) {
-	return c.getCtx(
-		context.Background(), endpoint, opts)
-}
-
 func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	var err error
 	var resp *http.Response
@@ -60,17 +55,11 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 	return resp, nil
 }
 
-func (c *Client) post(endpoint string, opts map[string]string) (*http.Response, error) {
-	return c.postCtx(context.Background(), endpoint, opts)
-}
-
 func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	// add optional parameters that the user wants
 	form := url.Values{}
-	if opts != nil {
-		for k, v := range opts {
-			form.Add(k, v)
-		}
+	for k, v := range opts {
+		form.Add(k, v)
 	}
 
 	var err error
@@ -115,17 +104,11 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	return resp, nil
 }
 
-func (c *Client) postBasic(endpoint string, opts map[string]string) (*http.Response, error) {
-	return c.postBasicCtx(context.Background(), endpoint, opts)
-}
-
 func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	// add optional parameters that the user wants
 	form := url.Values{}
-	if opts != nil {
-		for k, v := range opts {
-			form.Add(k, v)
-		}
+	for k, v := range opts {
+		form.Add(k, v)
 	}
 
 	var err error
@@ -153,10 +136,6 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	return resp, nil
 }
 
-func (c *Client) postFile(endpoint string, fileName string, opts map[string]string) (*http.Response, error) {
-	return c.postFileCtx(context.Background(), endpoint, fileName, opts)
-}
-
 func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName string, opts map[string]string) (*http.Response, error) {
 	var err error
 	var resp *http.Response
@@ -181,23 +160,19 @@ func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName stri
 	}
 
 	// Copy the actual file content to the fields writer
-	_, err = io.Copy(fileWriter, file)
-	if err != nil {
+	if _, err := io.Copy(fileWriter, file); err != nil {
 		return nil, errors.Wrap(err, "error copy file contents to writer %v", fileName)
 	}
 
 	// Populate other fields
-	if opts != nil {
-		for key, val := range opts {
-			fieldWriter, err := multiPartWriter.CreateFormField(key)
-			if err != nil {
-				return nil, errors.Wrap(err, "error creating form field %v with value %v", key, val)
-			}
+	for key, val := range opts {
+		fieldWriter, err := multiPartWriter.CreateFormField(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating form field %v with value %v", key, val)
+		}
 
-			_, err = fieldWriter.Write([]byte(val))
-			if err != nil {
-				return nil, errors.Wrap(err, "error writing field %v with value %v", key, val)
-			}
+		if _, err := fieldWriter.Write([]byte(val)); err != nil {
+			return nil, errors.Wrap(err, "error writing field %v with value %v", key, val)
 		}
 	}
 
@@ -253,10 +228,8 @@ func (c *Client) buildUrl(endpoint string, params map[string]string) string {
 
 	// add query params
 	queryParams := url.Values{}
-	if params != nil {
-		for key, value := range params {
-			queryParams.Add(key, value)
-		}
+	for key, value := range params {
+		queryParams.Add(key, value)
 	}
 
 	joinedUrl, _ := url.JoinPath(c.cfg.Host, apiBase, endpoint)

--- a/methods.go
+++ b/methods.go
@@ -226,7 +226,7 @@ func (c *Client) AddTorrentFromFileCtx(ctx context.Context, filePath string, opt
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not add torrent %v unexpected status: %v", filePath, res.StatusCode)
+		return errors.New("could not add torrent %v unexpected status: %v", filePath, res.StatusCode)
 	}
 
 	return nil
@@ -252,7 +252,7 @@ func (c *Client) AddTorrentFromUrlCtx(ctx context.Context, url string, options m
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not add torrent %v unexpected status: %v", url, res.StatusCode)
+		return errors.New("could not add torrent %v unexpected status: %v", url, res.StatusCode)
 	}
 
 	return nil
@@ -279,7 +279,7 @@ func (c *Client) DeleteTorrentsCtx(ctx context.Context, hashes []string, deleteF
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not delete torrents %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not delete torrents %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -304,7 +304,7 @@ func (c *Client) ReAnnounceTorrentsCtx(ctx context.Context, hashes []string) err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not re-announce torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not re-announce torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -354,7 +354,7 @@ func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not pause torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not pause torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -379,7 +379,7 @@ func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not resume torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not resume torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -405,7 +405,7 @@ func (c *Client) SetForceStartCtx(ctx context.Context, hashes []string, value bo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not setForceStart torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not setForceStart torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -430,7 +430,7 @@ func (c *Client) RecheckCtx(ctx context.Context, hashes []string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not recheck torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not recheck torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -456,7 +456,7 @@ func (c *Client) SetAutoManagementCtx(ctx context.Context, hashes []string, enab
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not setAutoManagement torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not setAutoManagement torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -482,7 +482,7 @@ func (c *Client) SetLocationCtx(ctx context.Context, hashes []string, location s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not setLocation torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not setLocation torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -506,7 +506,7 @@ func (c *Client) CreateCategoryCtx(ctx context.Context, category string, path st
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not createCategory torrents: %v unexpected status: %v", category, resp.StatusCode)
+		return errors.New("could not createCategory torrents: %v unexpected status: %v", category, resp.StatusCode)
 	}
 
 	return nil
@@ -530,7 +530,7 @@ func (c *Client) EditCategoryCtx(ctx context.Context, category string, path stri
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not editCategory torrents: %v unexpected status: %v", category, resp.StatusCode)
+		return errors.New("could not editCategory torrents: %v unexpected status: %v", category, resp.StatusCode)
 	}
 
 	return nil
@@ -553,7 +553,7 @@ func (c *Client) RemoveCategoriesCtx(ctx context.Context, categories []string) e
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not removeCategories torrents: %v unexpected status: %v", opts["categories"], resp.StatusCode)
+		return errors.New("could not removeCategories torrents: %v unexpected status: %v", opts["categories"], resp.StatusCode)
 	}
 
 	return nil
@@ -579,7 +579,7 @@ func (c *Client) SetCategoryCtx(ctx context.Context, hashes []string, category s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not setCategory torrents: %v unexpected status: %v", hashes, resp.StatusCode)
+		return errors.New("could not setCategory torrents: %v unexpected status: %v", hashes, resp.StatusCode)
 	}
 
 	return nil
@@ -658,7 +658,7 @@ func (c *Client) RenameFileCtx(ctx context.Context, hash, oldPath, newPath strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "could not renameFile: %v | old: %v | new: %v unexpected status: %v", hash, oldPath, newPath, resp.StatusCode)
+		return errors.New("could not renameFile: %v | old: %v | new: %v unexpected status: %v", hash, oldPath, newPath, resp.StatusCode)
 	}
 
 	return nil

--- a/methods.go
+++ b/methods.go
@@ -271,7 +271,7 @@ func (c *Client) DeleteTorrentsCtx(ctx context.Context, hashes []string, deleteF
 		"deleteFiles": strconv.FormatBool(deleteFiles),
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/delete", opts)
+	resp, err := c.postCtx(ctx, "torrents/delete", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not delete torrents: %+v", hashes)
 	}
@@ -296,7 +296,7 @@ func (c *Client) ReAnnounceTorrentsCtx(ctx context.Context, hashes []string) err
 		"hashes": hv,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/reannounce", opts)
+	resp, err := c.postCtx(ctx, "torrents/reannounce", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not re-announce torrents: %v", hashes)
 	}
@@ -346,7 +346,7 @@ func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 		"hashes": hv,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/pause", opts)
+	resp, err := c.postCtx(ctx, "torrents/pause", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not pause torrents: %v", hashes)
 	}
@@ -371,7 +371,7 @@ func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {
 		"hashes": hv,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/resume", opts)
+	resp, err := c.postCtx(ctx, "torrents/resume", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not resume torrents: %v", hashes)
 	}
@@ -397,7 +397,7 @@ func (c *Client) SetForceStartCtx(ctx context.Context, hashes []string, value bo
 		"value":  strconv.FormatBool(value),
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/setForceStart", opts)
+	resp, err := c.postCtx(ctx, "torrents/setForceStart", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not setForceStart torrents: %v", hashes)
 	}
@@ -422,7 +422,7 @@ func (c *Client) RecheckCtx(ctx context.Context, hashes []string) error {
 		"hashes": hv,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/recheck", opts)
+	resp, err := c.postCtx(ctx, "torrents/recheck", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not recheck torrents: %v", hashes)
 	}
@@ -448,7 +448,7 @@ func (c *Client) SetAutoManagementCtx(ctx context.Context, hashes []string, enab
 		"enable": strconv.FormatBool(enable),
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/setAutoManagement", opts)
+	resp, err := c.postCtx(ctx, "torrents/setAutoManagement", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not setAutoManagement torrents: %v", hashes)
 	}
@@ -498,7 +498,7 @@ func (c *Client) CreateCategoryCtx(ctx context.Context, category string, path st
 		"savePath": path,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/createCategory", opts)
+	resp, err := c.postCtx(ctx, "torrents/createCategory", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not createCategory torrents: %v", category)
 	}
@@ -522,7 +522,7 @@ func (c *Client) EditCategoryCtx(ctx context.Context, category string, path stri
 		"savePath": path,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/editCategory", opts)
+	resp, err := c.postCtx(ctx, "torrents/editCategory", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not editCategory torrents: %v", category)
 	}
@@ -545,7 +545,7 @@ func (c *Client) RemoveCategoriesCtx(ctx context.Context, categories []string) e
 		"categories": strings.Join(categories, "\n"),
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/removeCategories", opts)
+	resp, err := c.postCtx(ctx, "torrents/removeCategories", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not removeCategories torrents: %v", opts["categories"])
 	}
@@ -571,7 +571,7 @@ func (c *Client) SetCategoryCtx(ctx context.Context, hashes []string, category s
 		"category": category,
 	}
 
-	resp, err := c.getCtx(ctx, "torrents/setCategory", opts)
+	resp, err := c.postCtx(ctx, "torrents/setCategory", opts)
 	if err != nil {
 		return errors.Wrap(err, "could not setCategory torrents: %v", hashes)
 	}


### PR DESCRIPTION
Fix error handling, use POST for mutating http actions (required for 4.4.0+) and cleanup.