### PR TITLE
feat: improve retry handling and optimize auth

### DIFF
--- a/http.go
+++ b/http.go
@@ -262,6 +262,8 @@ func (c *Client) retryDo(ctx context.Context, req *http.Request) (*http.Response
 				return errors.New("qbit re-login")
 			} else if resp.StatusCode < 500 {
 				return err
+			} else if resp.StatusCode >= 500 {
+				return retry.Unrecoverable(errors.New("unrecoverable status: %v", resp.StatusCode))
 			}
 		}
 

--- a/http.go
+++ b/http.go
@@ -16,9 +16,6 @@ import (
 )
 
 func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
-	var err error
-	var resp *http.Response
-
 	reqUrl := c.buildUrl(endpoint, opts)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, nil)
@@ -30,24 +27,16 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
 
-	// try request and if fail run 10 retries
-	err = retry.Do(func() error {
-		resp, err = c.http.Do(req)
-		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.LoginCtx(ctx); err != nil {
-				return errors.Wrap(err, "qbit re-login failed")
-			}
-		} else if err != nil {
-			return errors.Wrap(err, "qbit POST failed")
+	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+
+	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+		if err := c.LoginCtx(ctx); err != nil {
+			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
+	}
 
-		return err
-	},
-		retry.OnRetry(func(n uint, err error) { c.log.Printf("%q: attempt %d - %v\n", err, n, reqUrl) }),
-		retry.Delay(time.Second*5),
-		retry.Attempts(10),
-		retry.MaxJitter(time.Second*1))
-
+	// try request and if fail run 10 retries
+	resp, err := c.retryDo(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making get request: %v", reqUrl)
 	}
@@ -61,9 +50,6 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	for k, v := range opts {
 		form.Add(k, v)
 	}
-
-	var err error
-	var resp *http.Response
 
 	reqUrl := c.buildUrl(endpoint, nil)
 
@@ -79,24 +65,15 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	// try request and if fail run 10 retries
-	err = retry.Do(func() error {
-		resp, err = c.http.Do(req)
-		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.LoginCtx(ctx); err != nil {
-				return errors.Wrap(err, "qbit re-login failed")
-			}
-		} else if err != nil {
-			return errors.Wrap(err, "qbit POST failed")
+	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+		if err := c.LoginCtx(ctx); err != nil {
+			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
+	}
 
-		return err
-	},
-		retry.OnRetry(func(n uint, err error) { c.log.Printf("%q: attempt %d - %v\n", err, n, reqUrl) }),
-		retry.Delay(time.Second*5),
-		retry.Attempts(10),
-		retry.MaxJitter(time.Second*1))
-
+	// try request and if fail run 10 retries
+	resp, err := c.retryDo(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making post request: %v", reqUrl)
 	}
@@ -111,7 +88,6 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 		form.Add(k, v)
 	}
 
-	var err error
 	var resp *http.Response
 
 	reqUrl := c.buildUrl(endpoint, nil)
@@ -137,9 +113,6 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 }
 
 func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName string, opts map[string]string) (*http.Response, error) {
-	var err error
-	var resp *http.Response
-
 	file, err := os.Open(fileName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening file %v", fileName)
@@ -177,7 +150,7 @@ func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName stri
 	}
 
 	// Close multipart writer
-	multiPartWriter.Close()
+	defer multiPartWriter.Close()
 
 	reqUrl := c.buildUrl(endpoint, nil)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqUrl, &requestBody)
@@ -192,24 +165,14 @@ func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName stri
 	// Set correct content type
 	req.Header.Set("Content-Type", multiPartWriter.FormDataContentType())
 
-	// try request and if fail run 10 retries
-	err = retry.Do(func() error {
-		resp, err = c.http.Do(req)
-		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			if err := c.LoginCtx(ctx); err != nil {
-				return errors.Wrap(err, "qbit re-login failed")
-			}
-		} else if err != nil {
-			return errors.Wrap(err, "qbit POST failed")
+	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+		if err := c.LoginCtx(ctx); err != nil {
+			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
+	}
 
-		return err
-	},
-		retry.OnRetry(func(n uint, err error) { c.log.Printf("%q: attempt %d - %v\n", err, n, reqUrl) }),
-		retry.Delay(time.Second*5),
-		retry.Attempts(10),
-		retry.MaxJitter(time.Second*1))
-
+	resp, err := c.retryDo(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making post file request %v", fileName)
 	}
@@ -238,4 +201,86 @@ func (c *Client) buildUrl(endpoint string, params map[string]string) string {
 
 	// make into new string and return
 	return parsedUrl.String()
+}
+
+func copyBody(src io.ReadCloser) ([]byte, error) {
+	b, err := io.ReadAll(src)
+	if err != nil {
+		// ErrReadingRequestBody
+		return nil, err
+	}
+	src.Close()
+	return b, nil
+}
+
+func resetBody(request *http.Request, originalBody []byte) {
+	request.Body = io.NopCloser(bytes.NewBuffer(originalBody))
+	request.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBuffer(originalBody)), nil
+	}
+}
+
+func (c *Client) retryDo(ctx context.Context, req *http.Request) (*http.Response, error) {
+	var (
+		originalBody []byte
+		err          error
+	)
+
+	if req != nil && req.Body != nil {
+		originalBody, err = copyBody(req.Body)
+		resetBody(req, originalBody)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var resp *http.Response
+
+	// try request and if fail run 10 retries
+	err = retry.Do(func() error {
+		resp, err = c.http.Do(req)
+
+		if err == nil {
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					retry.Unrecoverable(err)
+				}
+			}()
+
+			if resp.StatusCode == http.StatusForbidden {
+				if err := c.LoginCtx(ctx); err != nil {
+					return errors.Wrap(err, "qbit re-login failed")
+				}
+
+				if req.Body != nil {
+					resetBody(req, originalBody)
+				}
+
+				retry.Delay(100 * time.Millisecond)
+
+				return errors.New("qbit re-login")
+			} else if resp.StatusCode < 500 {
+				return err
+			}
+		}
+
+		//if req.Body != nil {
+		//	resetBody(req, originalBody)
+		//}
+		retry.Delay(time.Second * 3)
+
+		return err
+	},
+		retry.OnRetry(func(n uint, err error) { c.log.Printf("%q: attempt %d - %v\n", err, n, req.URL.String()) }),
+		//retry.Delay(time.Second*3),
+		retry.Attempts(5),
+		retry.MaxJitter(time.Second*1),
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error making request")
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
* retry handling
* optimize auth

Check for cookies before making a request. If we just restarted there are no cookies so then fire off a login if we have a username and password.

When qbit restarts the cookie will get invalid, so we handle requests when there is a cookie, but we get a 403 back.