### PR TITLE
feat(reannounce): return err on delete

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -2,6 +2,12 @@ package qbittorrent
 
 import (
 	"strconv"
+
+	"github.com/autobrr/go-qbittorrent/errors"
+)
+
+var (
+	ErrReannounceTookTooLong = errors.New("reannounce took too long, deleted torrent")
 )
 
 type Torrent struct {


### PR DESCRIPTION
This should fix an issue in autobrr where the status of actions does not get set and looks like they succeeded while torrents got removed from the client because reannounce reached max attempts.