### PR TITLE
fix: log in again, the cookie length is 0

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -57,7 +57,7 @@ func (c *Client) LoginCtx(ctx context.Context) error {
 	// place cookies in jar for future requests
 	if cookies := resp.Cookies(); len(cookies) > 0 {
 		c.setCookies(cookies)
-	} else {
+	} else if bodyString != "Ok." {
 		return errors.New("bad credentials")
 	}
 


### PR DESCRIPTION
When you log in again, the length of the cookie is 0, but the login is valid