### PR TITLE
feat(methods): make v5 compatible

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -437,6 +437,14 @@ func (c *Client) GetTransferInfoCtx(ctx context.Context) (*TransferInfo, error) 
 	return &info, nil
 }
 
+func (c *Client) Stop(hashes []string) error {
+	return c.PauseCtx(context.Background(), hashes)
+}
+
+func (c *Client) StopCtx(ctx context.Context, hashes []string) error {
+	return c.PauseCtx(ctx, hashes)
+}
+
 func (c *Client) Pause(hashes []string) error {
 	return c.PauseCtx(context.Background(), hashes)
 }


### PR DESCRIPTION
Make compatible with `v5.0.0`.

We need to rename endpoints for v5 for start/stop methods. Probably best to add webapi version as a property on the client struct and call that on login, and then check that to determine what to do.