### PR TITLE
feat: qBittorrent v5.x.x support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/autobrr/go-qbittorrent
 go 1.19
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/methods.go
+++ b/methods.go
@@ -495,6 +495,10 @@ func (c *Client) Stop(hashes []string) error {
 	return c.PauseCtx(context.Background(), hashes)
 }
 
+func (c *Client) StopCtx(ctx context.Context, hashes []string) error {
+	return c.PauseCtx(ctx, hashes)
+}
+
 func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 	// Add hashes together with | separator
 	hv := strings.Join(hashes, "|")
@@ -535,6 +539,10 @@ func (c *Client) Resume(hashes []string) error {
 
 func (c *Client) Start(hashes []string) error {
 	return c.ResumeCtx(context.Background(), hashes)
+}
+
+func (c *Client) StartCtx(ctx context.Context, hashes []string) error {
+	return c.ResumeCtx(ctx, hashes)
 }
 
 func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {

--- a/methods.go
+++ b/methods.go
@@ -105,12 +105,15 @@ func (c *Client) SetApiVersion(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) GetApiVersion() ApiVersion {
+func (c *Client) GetApiVersion() (ApiVersion, error) {
 	if c.version.Major == 0 && c.version.Minor == 0 && c.version.Patch == 0 {
-		c.SetApiVersion(context.Background())
+		err := c.SetApiVersion(context.Background())
+		if err != nil {
+			return ApiVersion{}, err
+		}
 	}
 
-	return c.version
+	return c.version, nil
 }
 
 func (c *Client) GetAppPreferences() (AppPreferences, error) {
@@ -502,7 +505,12 @@ func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 	endpoint := "torrents/stop"
 
 	// Qbt WebAPI 2.11 changed pause with stop
-	version := c.GetApiVersion()
+	version, err := c.GetApiVersion()
+
+	if err != nil {
+		return errors.Wrap(err, "could not get api version")
+	}
+
 	if version.Major <= 2 && version.Minor < 11 {
 		endpoint = "torrents/pause"
 	}
@@ -539,7 +547,12 @@ func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {
 	endpoint := "torrents/start"
 
 	// Qbt WebAPI 2.11 changed resume with start
-	version := c.GetApiVersion()
+	version, err := c.GetApiVersion()
+
+	if err != nil {
+		return errors.Wrap(err, "could not get api version")
+	}
+
 	if version.Major <= 2 && version.Minor < 11 {
 		endpoint = "torrents/resume"
 	}

--- a/methods.go
+++ b/methods.go
@@ -66,7 +66,7 @@ func (c *Client) LoginCtx(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) SetApiVersion(ctx context.Context) error {
+func (c *Client) setApiVersion() error {
 	version, err := c.GetWebAPIVersionCtx(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "could not get webapi version")
@@ -105,9 +105,9 @@ func (c *Client) SetApiVersion(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) GetApiVersion() (ApiVersion, error) {
+func (c *Client) getApiVersion() (ApiVersion, error) {
 	if c.version.Major == 0 && c.version.Minor == 0 && c.version.Patch == 0 {
-		err := c.SetApiVersion(context.Background())
+		err := c.setApiVersion()
 		if err != nil {
 			return ApiVersion{}, err
 		}
@@ -509,7 +509,7 @@ func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 	endpoint := "torrents/stop"
 
 	// Qbt WebAPI 2.11 changed pause with stop
-	version, err := c.GetApiVersion()
+	version, err := c.getApiVersion()
 
 	if err != nil {
 		return errors.Wrap(err, "could not get api version")
@@ -555,7 +555,7 @@ func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {
 	endpoint := "torrents/start"
 
 	// Qbt WebAPI 2.11 changed resume with start
-	version, err := c.GetApiVersion()
+	version, err := c.getApiVersion()
 
 	if err != nil {
 		return errors.Wrap(err, "could not get api version")

--- a/methods.go
+++ b/methods.go
@@ -511,7 +511,7 @@ func (c *Client) PauseCtx(ctx context.Context, hashes []string) error {
 		return errors.Wrap(err, "could not get api version")
 	}
 
-	if version.Major <= 2 && version.Minor < 11 {
+	if version.Major == 2 && version.Minor < 11 {
 		endpoint = "torrents/pause"
 	}
 
@@ -553,7 +553,7 @@ func (c *Client) ResumeCtx(ctx context.Context, hashes []string) error {
 		return errors.Wrap(err, "could not get api version")
 	}
 
-	if version.Major <= 2 && version.Minor < 11 {
+	if version.Major == 2 && version.Minor < 11 {
 		endpoint = "torrents/resume"
 	}
 

--- a/methods.go
+++ b/methods.go
@@ -63,11 +63,6 @@ func (c *Client) LoginCtx(ctx context.Context) error {
 
 	c.log.Printf("logged into client: %v", c.cfg.Host)
 
-	// set client version
-	if err := c.SetApiVersion(ctx); err != nil {
-		return errors.Wrap(err, "could not set api version")
-	}
-
 	return nil
 }
 
@@ -111,6 +106,10 @@ func (c *Client) SetApiVersion(ctx context.Context) error {
 }
 
 func (c *Client) GetApiVersion() ApiVersion {
+	if c.version.Major == 0 && c.version.Minor == 0 && c.version.Patch == 0 {
+		c.SetApiVersion(context.Background())
+	}
+
 	return c.version
 }
 

--- a/qbittorrent.go
+++ b/qbittorrent.go
@@ -16,6 +16,12 @@ var (
 	DefaultTimeout = 60 * time.Second
 )
 
+type ApiVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
 type Client struct {
 	cfg Config
 
@@ -23,6 +29,8 @@ type Client struct {
 	timeout time.Duration
 
 	log *log.Logger
+
+	version ApiVersion
 }
 
 type Config struct {

--- a/qbittorrent.go
+++ b/qbittorrent.go
@@ -9,18 +9,13 @@ import (
 	"net/http/cookiejar"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"golang.org/x/net/publicsuffix"
 )
 
 var (
 	DefaultTimeout = 60 * time.Second
 )
-
-type ApiVersion struct {
-	Major int
-	Minor int
-	Patch int
-}
 
 type Client struct {
 	cfg Config
@@ -30,7 +25,7 @@ type Client struct {
 
 	log *log.Logger
 
-	version ApiVersion
+	version *semver.Version
 }
 
 type Config struct {


### PR DESCRIPTION
An attempt at tackling webapi versioning.

qBittorrent v5 (webapi 2.11) had some API endpoint renaming:

`/torrents/pause` was renamed to `/torrents/stop`
`/torrents/resume` was renamed to `/torrents/start`