### PR TITLE
feat(methods): get torrent info includeTrackers introduced in qbit v.5.1

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -12,55 +12,56 @@ var (
 )
 
 type Torrent struct {
-	AddedOn            int64        `json:"added_on"`
-	AmountLeft         int64        `json:"amount_left"`
-	AutoManaged        bool         `json:"auto_tmm"`
-	Availability       float64      `json:"availability"`
-	Category           string       `json:"category"`
-	Completed          int64        `json:"completed"`
-	CompletionOn       int64        `json:"completion_on"`
-	ContentPath        string       `json:"content_path"`
-	DlLimit            int64        `json:"dl_limit"`
-	DlSpeed            int64        `json:"dlspeed"`
-	DownloadPath       string       `json:"download_path"`
-	Downloaded         int64        `json:"downloaded"`
-	DownloadedSession  int64        `json:"downloaded_session"`
-	ETA                int64        `json:"eta"`
-	FirstLastPiecePrio bool         `json:"f_l_piece_prio"`
-	ForceStart         bool         `json:"force_start"`
-	Hash               string       `json:"hash"`
-	InfohashV1         string       `json:"infohash_v1"`
-	InfohashV2         string       `json:"infohash_v2"`
-	LastActivity       int64        `json:"last_activity"`
-	MagnetURI          string       `json:"magnet_uri"`
-	MaxRatio           float64      `json:"max_ratio"`
-	MaxSeedingTime     int64        `json:"max_seeding_time"`
-	Name               string       `json:"name"`
-	NumComplete        int64        `json:"num_complete"`
-	NumIncomplete      int64        `json:"num_incomplete"`
-	NumLeechs          int64        `json:"num_leechs"`
-	NumSeeds           int64        `json:"num_seeds"`
-	Priority           int64        `json:"priority"`
-	Progress           float64      `json:"progress"`
-	Ratio              float64      `json:"ratio"`
-	RatioLimit         float64      `json:"ratio_limit"`
-	SavePath           string       `json:"save_path"`
-	SeedingTime        int64        `json:"seeding_time"`
-	SeedingTimeLimit   int64        `json:"seeding_time_limit"`
-	SeenComplete       int64        `json:"seen_complete"`
-	SequentialDownload bool         `json:"seq_dl"`
-	Size               int64        `json:"size"`
-	State              TorrentState `json:"state"`
-	SuperSeeding       bool         `json:"super_seeding"`
-	Tags               string       `json:"tags"`
-	TimeActive         int64        `json:"time_active"`
-	TotalSize          int64        `json:"total_size"`
-	Tracker            string       `json:"tracker"`
-	TrackersCount      int64        `json:"trackers_count"`
-	UpLimit            int64        `json:"up_limit"`
-	Uploaded           int64        `json:"uploaded"`
-	UploadedSession    int64        `json:"uploaded_session"`
-	UpSpeed            int64        `json:"upspeed"`
+	AddedOn            int64            `json:"added_on"`
+	AmountLeft         int64            `json:"amount_left"`
+	AutoManaged        bool             `json:"auto_tmm"`
+	Availability       float64          `json:"availability"`
+	Category           string           `json:"category"`
+	Completed          int64            `json:"completed"`
+	CompletionOn       int64            `json:"completion_on"`
+	ContentPath        string           `json:"content_path"`
+	DlLimit            int64            `json:"dl_limit"`
+	DlSpeed            int64            `json:"dlspeed"`
+	DownloadPath       string           `json:"download_path"`
+	Downloaded         int64            `json:"downloaded"`
+	DownloadedSession  int64            `json:"downloaded_session"`
+	ETA                int64            `json:"eta"`
+	FirstLastPiecePrio bool             `json:"f_l_piece_prio"`
+	ForceStart         bool             `json:"force_start"`
+	Hash               string           `json:"hash"`
+	InfohashV1         string           `json:"infohash_v1"`
+	InfohashV2         string           `json:"infohash_v2"`
+	LastActivity       int64            `json:"last_activity"`
+	MagnetURI          string           `json:"magnet_uri"`
+	MaxRatio           float64          `json:"max_ratio"`
+	MaxSeedingTime     int64            `json:"max_seeding_time"`
+	Name               string           `json:"name"`
+	NumComplete        int64            `json:"num_complete"`
+	NumIncomplete      int64            `json:"num_incomplete"`
+	NumLeechs          int64            `json:"num_leechs"`
+	NumSeeds           int64            `json:"num_seeds"`
+	Priority           int64            `json:"priority"`
+	Progress           float64          `json:"progress"`
+	Ratio              float64          `json:"ratio"`
+	RatioLimit         float64          `json:"ratio_limit"`
+	SavePath           string           `json:"save_path"`
+	SeedingTime        int64            `json:"seeding_time"`
+	SeedingTimeLimit   int64            `json:"seeding_time_limit"`
+	SeenComplete       int64            `json:"seen_complete"`
+	SequentialDownload bool             `json:"seq_dl"`
+	Size               int64            `json:"size"`
+	State              TorrentState     `json:"state"`
+	SuperSeeding       bool             `json:"super_seeding"`
+	Tags               string           `json:"tags"`
+	TimeActive         int64            `json:"time_active"`
+	TotalSize          int64            `json:"total_size"`
+	Tracker            string           `json:"tracker"`
+	TrackersCount      int64            `json:"trackers_count"`
+	UpLimit            int64            `json:"up_limit"`
+	Uploaded           int64            `json:"uploaded"`
+	UploadedSession    int64            `json:"uploaded_session"`
+	UpSpeed            int64            `json:"upspeed"`
+	Trackers           []TorrentTracker `json:"trackers"`
 }
 
 type TorrentTrackersResponse struct {
@@ -358,14 +359,15 @@ func (o *TorrentAddOptions) Prepare() map[string]string {
 }
 
 type TorrentFilterOptions struct {
-	Filter   TorrentFilter
-	Category string
-	Tag      string
-	Sort     string
-	Reverse  bool
-	Limit    int
-	Offset   int
-	Hashes   []string
+	Filter          TorrentFilter
+	Category        string
+	Tag             string
+	Sort            string
+	Reverse         bool
+	Limit           int
+	Offset          int
+	Hashes          []string
+	IncludeTrackers bool // qbit 5.1+
 }
 
 type TorrentProperties struct {

--- a/methods.go
+++ b/methods.go
@@ -188,6 +188,11 @@ func (c *Client) GetTorrentsCtx(ctx context.Context, o TorrentFilterOptions) ([]
 		opts["hashes"] = strings.Join(o.Hashes, "|")
 	}
 
+	// qbit v5.1+
+	if o.IncludeTrackers {
+		opts["includeTrackers"] = strconv.FormatBool(o.IncludeTrackers)
+	}
+
 	resp, err := c.getCtx(ctx, "torrents/info", opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "get torrents error")


### PR DESCRIPTION
Add option `includeTrackers` to torrents/info call to fetch trackers in the same request.

Will be included in a future qBittorrent version, likely v5.1

Related https://github.com/qbittorrent/qBittorrent/pull/22128