### PR TITLE
feat(client): set custom http client

### DIFF
--- a/qbittorrent.go
+++ b/qbittorrent.go
@@ -96,3 +96,10 @@ func NewClient(cfg Config) *Client {
 
 	return c
 }
+
+// WithHTTPClient allows you to a provide a custom [http.Client].
+func (r *Client) WithHTTPClient(client *http.Client) *Client {
+	client.Jar = r.http.Jar
+	r.http = client
+	return r
+}


### PR DESCRIPTION
This adds a method to configure a custom http.Client.
