### PR TITLE
feat(torrent): add some missing fields

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -60,6 +60,8 @@ type Torrent struct {
 	Hash               string           `json:"hash"`
 	InfohashV1         string           `json:"infohash_v1"`
 	InfohashV2         string           `json:"infohash_v2"`
+	Popularity         float64          `json:"popularity"`
+	Private            bool             `json:"private"`
 	LastActivity       int64            `json:"last_activity"`
 	MagnetURI          string           `json:"magnet_uri"`
 	MaxRatio           float64          `json:"max_ratio"`
@@ -73,6 +75,7 @@ type Torrent struct {
 	Progress           float64          `json:"progress"`
 	Ratio              float64          `json:"ratio"`
 	RatioLimit         float64          `json:"ratio_limit"`
+	Reannounce         int64            `json:"reannounce"`
 	SavePath           string           `json:"save_path"`
 	SeedingTime        int64            `json:"seeding_time"`
 	SeedingTimeLimit   int64            `json:"seeding_time_limit"`

--- a/filter_generated.go
+++ b/filter_generated.go
@@ -180,6 +180,25 @@ func compareInfohashV2(a, b *Torrent) int {
 	return 1
 }
 
+func comparePopularity(a, b *Torrent) int {
+	if a.Popularity < b.Popularity {
+		return -1
+	} else if a.Popularity > b.Popularity {
+		return 1
+	}
+	return 0
+}
+
+func comparePrivate(a, b *Torrent) int {
+	if a.Private != b.Private {
+		if a.Private {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
 func compareLastActivity(a, b *Torrent) int {
 	if a.LastActivity < b.LastActivity {
 		return -1
@@ -292,6 +311,15 @@ func compareRatioLimit(a, b *Torrent) int {
 	if a.RatioLimit < b.RatioLimit {
 		return -1
 	} else if a.RatioLimit > b.RatioLimit {
+		return 1
+	}
+	return 0
+}
+
+func compareReannounce(a, b *Torrent) int {
+	if a.Reannounce < b.Reannounce {
+		return -1
+	} else if a.Reannounce > b.Reannounce {
 		return 1
 	}
 	return 0
@@ -482,6 +510,8 @@ var torrentComparators = map[string]func(a, b *Torrent) int{
 	"hash": compareHash,
 	"infohash_v1": compareInfohashV1,
 	"infohash_v2": compareInfohashV2,
+	"popularity": comparePopularity,
+	"private": comparePrivate,
 	"last_activity": compareLastActivity,
 	"magnet_uri": compareMagnetURI,
 	"max_ratio": compareMaxRatio,
@@ -495,6 +525,7 @@ var torrentComparators = map[string]func(a, b *Torrent) int{
 	"progress": compareProgress,
 	"ratio": compareRatio,
 	"ratio_limit": compareRatioLimit,
+	"reannounce": compareReannounce,
 	"save_path": compareSavePath,
 	"seeding_time": compareSeedingTime,
 	"seeding_time_limit": compareSeedingTimeLimit,

--- a/maindata_updaters_generated.go
+++ b/maindata_updaters_generated.go
@@ -136,6 +136,20 @@ func updateTorrentInfohashV2(val interface{}, obj *Torrent) {
 	}
 }
 
+// updateTorrentPopularity updates the Popularity field of Torrent
+func updateTorrentPopularity(val interface{}, obj *Torrent) {
+	if p, ok := val.(float64); ok {
+		obj.Popularity = p
+	}
+}
+
+// updateTorrentPrivate updates the Private field of Torrent
+func updateTorrentPrivate(val interface{}, obj *Torrent) {
+	if p, ok := val.(bool); ok {
+		obj.Private = p
+	}
+}
+
 // updateTorrentLastActivity updates the LastActivity field of Torrent
 func updateTorrentLastActivity(val interface{}, obj *Torrent) {
 	if l, ok := val.(float64); ok {
@@ -224,6 +238,13 @@ func updateTorrentRatio(val interface{}, obj *Torrent) {
 func updateTorrentRatioLimit(val interface{}, obj *Torrent) {
 	if r, ok := val.(float64); ok {
 		obj.RatioLimit = r
+	}
+}
+
+// updateTorrentReannounce updates the Reannounce field of Torrent
+func updateTorrentReannounce(val interface{}, obj *Torrent) {
+	if r, ok := val.(float64); ok {
+		obj.Reannounce = int64(r)
 	}
 }
 
@@ -383,6 +404,8 @@ var torrentFieldUpdaters = map[string]func(val interface{}, obj *Torrent){
 	"hash": updateTorrentHash,
 	"infohash_v1": updateTorrentInfohashV1,
 	"infohash_v2": updateTorrentInfohashV2,
+	"popularity": updateTorrentPopularity,
+	"private": updateTorrentPrivate,
 	"last_activity": updateTorrentLastActivity,
 	"magnet_uri": updateTorrentMagnetURI,
 	"max_ratio": updateTorrentMaxRatio,
@@ -396,6 +419,7 @@ var torrentFieldUpdaters = map[string]func(val interface{}, obj *Torrent){
 	"progress": updateTorrentProgress,
 	"ratio": updateTorrentRatio,
 	"ratio_limit": updateTorrentRatioLimit,
+	"reannounce": updateTorrentReannounce,
 	"save_path": updateTorrentSavePath,
 	"seeding_time": updateTorrentSeedingTime,
 	"seeding_time_limit": updateTorrentSeedingTimeLimit,


### PR DESCRIPTION
Adds `Reannounce`, `Popularity` and `Private` fields to the Torrent struct to add support for more columns in https://github.com/autobrr/qui/pull/272