### PR TITLE
refactor: make TorrentFiles item a separate type

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -124,7 +124,9 @@ type TorrentTracker struct {
 	Message       string        `json:"msg"`
 }
 
-type TorrentFiles []struct {
+type TorrentFiles []TorrentFile
+
+type TorrentFile struct {
 	Availability float32 `json:"availability"`
 	Index        int     `json:"index"`
 	IsSeed       bool    `json:"is_seed,omitempty"`


### PR DESCRIPTION
Otherwise it's hard to work with the results of `GetFilesInformation`, because it can't be used in function signatures or structs.