### PR TITLE
feat: support api key authentication

### DIFF
--- a/http.go
+++ b/http.go
@@ -17,6 +17,8 @@ import (
 	"github.com/avast/retry-go"
 )
 
+const authorizationHeader = "Authorization"
+
 func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	reqUrl := c.buildUrl(endpoint, opts)
 
@@ -28,10 +30,11 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
+	c.setAPIKeyAuthHeader(req)
 
 	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
 
-	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
 		if err := c.LoginCtx(ctx); err != nil {
 			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
@@ -63,12 +66,13 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
+	c.setAPIKeyAuthHeader(req)
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
 		if err := c.LoginCtx(ctx); err != nil {
 			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
@@ -102,6 +106,7 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
+	c.setAPIKeyAuthHeader(req)
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -176,7 +181,7 @@ func (c *Client) postMultiMemoryCtx(ctx context.Context, endpoint string, files 
 	req.Header.Set("Content-Type", contentType)
 
 	cookieURL, _ := url.Parse(c.buildUrl("/", nil)) //nolint:errcheck // buildUrl returns valid URL
-	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
 		if loginErr := c.LoginCtx(ctx); loginErr != nil {
 			return nil, errors.Wrap(loginErr, "qbit re-login failed")
 		}
@@ -234,12 +239,13 @@ func (c *Client) postReaderCtx(ctx context.Context, endpoint string, reader io.R
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
+	c.setAPIKeyAuthHeader(req)
 
 	// Set correct content type
 	req.Header.Set("Content-Type", contentType)
 
 	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-	if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
 		if err := c.LoginCtx(ctx); err != nil {
 			return nil, errors.Wrap(err, "qbit re-login failed")
 		}
@@ -270,6 +276,16 @@ func (c *Client) setCookies(cookies []*http.Cookie) {
 	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
 
 	c.http.Jar.SetCookies(cookieURL, cookies)
+}
+
+func (c *Client) usingAPIKeyAuth() bool {
+	return c.cfg.APIKey != ""
+}
+
+func (c *Client) setAPIKeyAuthHeader(req *http.Request) {
+	if c.cfg.APIKey != "" {
+		req.Header.Set(authorizationHeader, "Bearer "+c.cfg.APIKey)
+	}
 }
 
 func (c *Client) buildUrl(endpoint string, params map[string]string) string {
@@ -386,6 +402,9 @@ func (c *Client) retryDo(ctx context.Context, req *http.Request) (*http.Response
 		}
 
 		if resp.StatusCode == http.StatusForbidden {
+			if c.usingAPIKeyAuth() {
+				return nil
+			}
 			drainAndClose(resp)
 			if err := c.LoginCtx(ctx); err != nil {
 				return errors.Wrap(err, "qbit re-login failed")

--- a/http.go
+++ b/http.go
@@ -400,10 +400,10 @@ func (c *Client) retryDo(ctx context.Context, req *http.Request) (*http.Response
 		}
 
 		if resp.StatusCode == http.StatusForbidden {
+			drainAndClose(resp)
 			if c.usingAPIKeyAuth() {
 				return nil
 			}
-			drainAndClose(resp)
 			if err := c.LoginCtx(ctx); err != nil {
 				return errors.Wrap(err, "qbit re-login failed")
 			}

--- a/http.go
+++ b/http.go
@@ -28,13 +28,14 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-	c.setAPIKeyAuthHeader(req)
-
-	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-
-	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
-		if err := c.LoginCtx(ctx); err != nil {
-			return nil, errors.Wrap(err, "qbit re-login failed")
+	if c.usingAPIKeyAuth() {
+		c.setAPIKeyAuthHeader(req)
+	} else {
+		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+			if err := c.LoginCtx(ctx); err != nil {
+				return nil, errors.Wrap(err, "qbit re-login failed")
+			}
 		}
 	}
 
@@ -64,17 +65,19 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-	c.setAPIKeyAuthHeader(req)
+	if c.usingAPIKeyAuth() {
+		c.setAPIKeyAuthHeader(req)
+	} else {
+		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+			if err := c.LoginCtx(ctx); err != nil {
+				return nil, errors.Wrap(err, "qbit re-login failed")
+			}
+		}
+	}
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
-		if err := c.LoginCtx(ctx); err != nil {
-			return nil, errors.Wrap(err, "qbit re-login failed")
-		}
-	}
 
 	// try request and if fail run 10 retries
 	resp, err := c.retryDo(ctx, req)
@@ -104,7 +107,16 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-	c.setAPIKeyAuthHeader(req)
+	if c.usingAPIKeyAuth() {
+		c.setAPIKeyAuthHeader(req)
+	} else {
+		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+			if err := c.LoginCtx(ctx); err != nil {
+				return nil, errors.Wrap(err, "qbit re-login failed")
+			}
+		}
+	}
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -175,15 +187,18 @@ func (c *Client) postMultiMemoryCtx(ctx context.Context, endpoint string, files 
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-
-	req.Header.Set("Content-Type", contentType)
-
-	cookieURL, _ := url.Parse(c.buildUrl("/", nil)) //nolint:errcheck // buildUrl returns valid URL
-	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
-		if loginErr := c.LoginCtx(ctx); loginErr != nil {
-			return nil, errors.Wrap(loginErr, "qbit re-login failed")
+	if c.usingAPIKeyAuth() {
+		c.setAPIKeyAuthHeader(req)
+	} else {
+		cookieURL, _ := url.Parse(c.buildUrl("/", nil)) //nolint:errcheck // buildUrl returns valid URL
+		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+			if loginErr := c.LoginCtx(ctx); loginErr != nil {
+				return nil, errors.Wrap(loginErr, "qbit re-login failed")
+			}
 		}
 	}
+
+	req.Header.Set("Content-Type", contentType)
 
 	resp, err := c.retryDo(ctx, req)
 	if err != nil {
@@ -237,17 +252,19 @@ func (c *Client) postReaderCtx(ctx context.Context, endpoint string, reader io.R
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-	c.setAPIKeyAuthHeader(req)
+	if c.usingAPIKeyAuth() {
+		c.setAPIKeyAuthHeader(req)
+	} else {
+		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
+		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
+			if err := c.LoginCtx(ctx); err != nil {
+				return nil, errors.Wrap(err, "qbit re-login failed")
+			}
+		}
+	}
 
 	// Set correct content type
 	req.Header.Set("Content-Type", contentType)
-
-	cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-	if !c.usingAPIKeyAuth() && len(c.http.Jar.Cookies(cookieURL)) == 0 {
-		if err := c.LoginCtx(ctx); err != nil {
-			return nil, errors.Wrap(err, "qbit re-login failed")
-		}
-	}
 
 	resp, err := c.retryDo(ctx, req)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -17,8 +17,6 @@ import (
 	"github.com/avast/retry-go"
 )
 
-const authorizationHeader = "Authorization"
-
 func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	reqUrl := c.buildUrl(endpoint, opts)
 
@@ -284,7 +282,7 @@ func (c *Client) usingAPIKeyAuth() bool {
 
 func (c *Client) setAPIKeyAuthHeader(req *http.Request) {
 	if c.cfg.APIKey != "" {
-		req.Header.Set(authorizationHeader, "Bearer "+c.cfg.APIKey)
+		req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
 	}
 }
 

--- a/methods.go
+++ b/methods.go
@@ -20,6 +20,10 @@ func (c *Client) Login() error {
 }
 
 func (c *Client) LoginCtx(ctx context.Context) error {
+	if c.usingAPIKeyAuth() {
+		return nil
+	}
+
 	if c.cfg.Username == "" && c.cfg.Password == "" {
 		return nil
 	}

--- a/qbittorrent.go
+++ b/qbittorrent.go
@@ -35,6 +35,7 @@ type Config struct {
 	Host     string
 	Username string
 	Password string
+	APIKey   string
 
 	// TLS skip cert validation
 	TLSSkipVerify bool


### PR DESCRIPTION
This PR adds support for API keysauthentication with a `Bearer` token for qBittorrent 5.2.0 onwards.

## Testing

- [x] Tested by AI with a supplementary main.go for authenticating with a qBittorrent 5.2.0 instance
- [x] Tested with qui (see https://github.com/autobrr/qui/pull/1854)