### PR TITLE
feat(api): get free disk space at path

### DIFF
--- a/free_space_test.go
+++ b/free_space_test.go
@@ -1,6 +1,7 @@
 package qbittorrent
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"net/http"
@@ -14,28 +15,33 @@ func TestClient_GetFreeSpaceAtPathCtx(t *testing.T) {
 
 	for _, tt := range []struct {
 		name    string
+		apiVer  string
 		body    string
 		status  int
 		want    int64
 		wantErr error
 	}{
-		{"positive", "1099511627776", http.StatusOK, 1099511627776, nil},
-		{"zero", "0", http.StatusOK, 0, nil},
-		{"unavailable", "-1", http.StatusOK, -1, nil},
-		{"negative", "-42", http.StatusOK, -42, nil},
-		{"max int64", "9223372036854775807", http.StatusOK, 9223372036854775807, nil},
-		{"min int64", "-9223372036854775808", http.StatusOK, -9223372036854775808, nil},
-		{"empty", "", http.StatusOK, 0, strconv.ErrSyntax},
-		{"invalid", "unavailable", http.StatusOK, 0, strconv.ErrSyntax},
-		{"fraction", "1.5", http.StatusOK, 0, strconv.ErrSyntax},
-		{"trailing data", "123\n456", http.StatusOK, 0, strconv.ErrSyntax},
-		{"overflow", "9223372036854775808", http.StatusOK, 0, strconv.ErrRange},
-		{"underflow", "-9223372036854775809", http.StatusOK, 0, strconv.ErrRange},
-		{"unsupported server", "Not Found", http.StatusNotFound, 0, ErrUnexpectedStatus},
-		{"bad request", "Bad Request", http.StatusBadRequest, 0, ErrUnexpectedStatus},
+		{"positive", "", "1099511627776", http.StatusOK, 1099511627776, nil},
+		{"zero", "", "0", http.StatusOK, 0, nil},
+		{"unavailable", "", "-1", http.StatusOK, -1, nil},
+		{"negative", "", "-42", http.StatusOK, -42, nil},
+		{"max int64", "", "9223372036854775807", http.StatusOK, 9223372036854775807, nil},
+		{"min int64", "", "-9223372036854775808", http.StatusOK, -9223372036854775808, nil},
+		{"empty", "", "", http.StatusOK, 0, strconv.ErrSyntax},
+		{"invalid", "", "unavailable", http.StatusOK, 0, strconv.ErrSyntax},
+		{"fraction", "", "1.5", http.StatusOK, 0, strconv.ErrSyntax},
+		{"trailing data", "", "123\n456", http.StatusOK, 0, strconv.ErrSyntax},
+		{"overflow", "", "9223372036854775808", http.StatusOK, 0, strconv.ErrRange},
+		{"underflow", "", "-9223372036854775809", http.StatusOK, 0, strconv.ErrRange},
+		{"unsupported server", "", "Not Found", http.StatusNotFound, 0, ErrUnexpectedStatus},
+		{"bad request", "", "Bad Request", http.StatusBadRequest, 0, ErrUnexpectedStatus},
+		{"old server", "2.15.1", "", 0, 0, ErrUnsupportedVersion},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := http.NewServeMux()
+			mux.HandleFunc("GET /api/v2/app/webapiVersion", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(cmp.Or(tt.apiVer, "2.15.2")))
+			})
 			mux.HandleFunc("GET /api/v2/app/getFreeSpaceAtPath", func(w http.ResponseWriter, r *http.Request) {
 				query := r.URL.Query()
 				if len(query) != 1 || len(query["path"]) != 1 || query.Get("path") != path {
@@ -61,9 +67,14 @@ func TestClient_GetFreeSpaceAtPathCtx(t *testing.T) {
 }
 
 func TestClient_GetFreeSpaceAtPathCtx_Canceled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v2/app/webapiVersion", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("2.15.2"))
+	})
+	mux.HandleFunc("GET /api/v2/app/getFreeSpaceAtPath", func(http.ResponseWriter, *http.Request) {
 		t.Error("canceled request reached the server")
-	}))
+	})
+	server := httptest.NewServer(mux)
 	defer server.Close()
 	client := NewClient(Config{Host: server.URL, RetryAttempts: 1})
 	ctx, cancel := context.WithCancel(t.Context())

--- a/free_space_test.go
+++ b/free_space_test.go
@@ -1,0 +1,75 @@
+package qbittorrent
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+func TestClient_GetFreeSpaceAtPathCtx(t *testing.T) {
+	const path = "/remote/downloads/new folder/日本語 + & # ? %/child"
+
+	for _, tt := range []struct {
+		name    string
+		body    string
+		status  int
+		want    int64
+		wantErr error
+	}{
+		{"positive", "1099511627776", http.StatusOK, 1099511627776, nil},
+		{"zero", "0", http.StatusOK, 0, nil},
+		{"unavailable", "-1", http.StatusOK, -1, nil},
+		{"negative", "-42", http.StatusOK, -42, nil},
+		{"max int64", "9223372036854775807", http.StatusOK, 9223372036854775807, nil},
+		{"min int64", "-9223372036854775808", http.StatusOK, -9223372036854775808, nil},
+		{"empty", "", http.StatusOK, 0, strconv.ErrSyntax},
+		{"invalid", "unavailable", http.StatusOK, 0, strconv.ErrSyntax},
+		{"fraction", "1.5", http.StatusOK, 0, strconv.ErrSyntax},
+		{"trailing data", "123\n456", http.StatusOK, 0, strconv.ErrSyntax},
+		{"overflow", "9223372036854775808", http.StatusOK, 0, strconv.ErrRange},
+		{"underflow", "-9223372036854775809", http.StatusOK, 0, strconv.ErrRange},
+		{"unsupported server", "Not Found", http.StatusNotFound, 0, ErrUnexpectedStatus},
+		{"bad request", "Bad Request", http.StatusBadRequest, 0, ErrUnexpectedStatus},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /api/v2/app/getFreeSpaceAtPath", func(w http.ResponseWriter, r *http.Request) {
+				query := r.URL.Query()
+				if len(query) != 1 || len(query["path"]) != 1 || query.Get("path") != path {
+					t.Errorf("query = %v, want only path=%q", query, path)
+				}
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			client := NewClient(Config{Host: server.URL, RetryAttempts: 1})
+
+			got, err := client.GetFreeSpaceAtPathCtx(t.Context(), path)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("GetFreeSpaceAtPathCtx() error = %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("GetFreeSpaceAtPathCtx() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetFreeSpaceAtPathCtx_Canceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("canceled request reached the server")
+	}))
+	defer server.Close()
+	client := NewClient(Config{Host: server.URL, RetryAttempts: 1})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	if _, err := client.GetFreeSpaceAtPathCtx(ctx, "/remote/downloads"); err == nil {
+		t.Fatal("GetFreeSpaceAtPathCtx() returned no error for a canceled context")
+	}
+}

--- a/methods.go
+++ b/methods.go
@@ -2573,6 +2573,32 @@ func (c *Client) GetFreeSpaceOnDiskCtx(ctx context.Context) (int64, error) {
 	return info.ServerState.FreeSpaceOnDisk, nil
 }
 
+func (c *Client) GetFreeSpaceAtPath(path string) (int64, error) {
+	return c.GetFreeSpaceAtPathCtx(context.Background(), path)
+}
+
+// GetFreeSpaceAtPathCtx get free space on disk for a specific path. qBittorrent 5.3 webapi 2.15.2
+func (c *Client) GetFreeSpaceAtPathCtx(ctx context.Context, path string) (int64, error) {
+	opts := map[string]string{"path": path}
+	resp, err := c.getCtx(ctx, "app/getFreeSpaceAtPath", opts)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not get free space at path")
+	}
+
+	defer drainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, errors.Wrap(ErrUnexpectedStatus, "could not get free space at path; status code: %d", resp.StatusCode)
+	}
+
+	var m int64
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return 0, errors.Wrap(err, "could not unmarshal body")
+	}
+
+	return 0, nil
+}
+
 // RequiresMinVersion checks the current version against version X and errors if the current version is older than X
 func (c *Client) RequiresMinVersion(minVersion *semver.Version) (bool, error) {
 	version, err := c.getApiVersion()

--- a/methods.go
+++ b/methods.go
@@ -2574,15 +2574,19 @@ func (c *Client) GetFreeSpaceOnDiskCtx(ctx context.Context) (int64, error) {
 }
 
 // GetFreeSpaceAtPath returns free bytes at path on the qBittorrent host.
-// It requires WebAPI 2.15.2 or later. A negative result means free space is unavailable.
+// It requires qBittorrent 5.3 and WebAPI 2.15.2 or later. A negative result means free space is unavailable.
 func (c *Client) GetFreeSpaceAtPath(path string) (int64, error) {
 	return c.GetFreeSpaceAtPathCtx(context.Background(), path)
 }
 
 // GetFreeSpaceAtPathCtx returns free bytes at path on the qBittorrent host.
-// It requires WebAPI 2.15.2 or later. A negative result means free space is unavailable.
+// It requires qBittorrent 5.3 and WebAPI 2.15.2 or later. A negative result means free space is unavailable.
 // If path does not exist, qBittorrent queries its parent directories.
 func (c *Client) GetFreeSpaceAtPathCtx(ctx context.Context, path string) (int64, error) {
+	if ok, err := c.RequiresMinVersion(semver.MustParse("2.15.2")); !ok {
+		return 0, errors.Wrap(err, "GetFreeSpaceAtPath requires qBittorrent 5.3 and WebAPI >= 2.15.2")
+	}
+
 	opts := map[string]string{"path": path}
 	resp, err := c.getCtx(ctx, "app/getFreeSpaceAtPath", opts)
 	if err != nil {

--- a/methods.go
+++ b/methods.go
@@ -2573,11 +2573,15 @@ func (c *Client) GetFreeSpaceOnDiskCtx(ctx context.Context) (int64, error) {
 	return info.ServerState.FreeSpaceOnDisk, nil
 }
 
+// GetFreeSpaceAtPath returns free bytes at path on the qBittorrent host.
+// It requires WebAPI 2.15.2 or later. A negative result means free space is unavailable.
 func (c *Client) GetFreeSpaceAtPath(path string) (int64, error) {
 	return c.GetFreeSpaceAtPathCtx(context.Background(), path)
 }
 
-// GetFreeSpaceAtPathCtx get free space on disk for a specific path. qBittorrent 5.3 webapi 2.15.2
+// GetFreeSpaceAtPathCtx returns free bytes at path on the qBittorrent host.
+// It requires WebAPI 2.15.2 or later. A negative result means free space is unavailable.
+// If path does not exist, qBittorrent queries its parent directories.
 func (c *Client) GetFreeSpaceAtPathCtx(ctx context.Context, path string) (int64, error) {
 	opts := map[string]string{"path": path}
 	resp, err := c.getCtx(ctx, "app/getFreeSpaceAtPath", opts)
@@ -2591,12 +2595,17 @@ func (c *Client) GetFreeSpaceAtPathCtx(ctx context.Context, path string) (int64,
 		return 0, errors.Wrap(ErrUnexpectedStatus, "could not get free space at path; status code: %d", resp.StatusCode)
 	}
 
-	var m int64
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
-		return 0, errors.Wrap(err, "could not unmarshal body")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not read body")
 	}
 
-	return 0, nil
+	freeSpace, err := strconv.ParseInt(string(body), 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not parse free space at path")
+	}
+
+	return freeSpace, nil
 }
 
 // RequiresMinVersion checks the current version against version X and errors if the current version is older than X


### PR DESCRIPTION
Adds free-space queries for a path on the qBittorrent host, with signed byte counts and server-side parent lookup.

Requires WebAPI 2.15.2 or later. Negative results mean free space is unavailable.

Verified against qBittorrent source at `607c9881e`. CI covers the HTTP fixtures.

Closes #138. Merge after #137 and autobrr/qui#2598.

## AI disclosure

Codex updated response parsing, documentation, and tests.
