### PR TITLE
feat: Add TrackerStatus 5 and 6 for Web API 2.13.0

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -266,7 +266,10 @@ const (
 
 	// Torrent is moving
 	TorrentFilterMoving TorrentFilter = "moving"
-) // TrackerStatus https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
+)
+
+// TrackerStatus is the numeric status from torrents/trackers and sync payloads; see
+// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
 type TrackerStatus int
 
 const (
@@ -282,8 +285,14 @@ const (
 	// 3 Tracker is updating
 	TrackerStatusUpdating TrackerStatus = 3
 
-	// 4 Tracker has been contacted, but it is not working (or doesn't send proper replies)
+	// 4 Not working: generic announce failure; Web API 2.13+ adds 5 and 6 for finer-grained failures
 	TrackerStatusNotWorking TrackerStatus = 4
+
+	// 5 Tracker error: explicit tracker-side error (not unreachable; not generic 4)
+	TrackerStatusTrackerError TrackerStatus = 5
+
+	// 6 Unreachable: cannot connect to the tracker (vs 5: tracker returned an error instead)
+	TrackerStatusUnreachable TrackerStatus = 6
 )
 
 type ConnectionStatus string

--- a/methods.go
+++ b/methods.go
@@ -3080,14 +3080,10 @@ func (c *Client) DeleteTorrentCreationTaskCtx(ctx context.Context, taskID string
 	}
 }
 
-// Check if status not working or something else
-// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
+// Check if at least one non-disabled tracker reports status OK (2). Status values are
+// TrackerStatus* in domain.go (inline comments on 4-6 describe how they differ).
 //
-//	0 Tracker is disabled (used for DHT, PeX, and LSD)
-//	1 Tracker has not been contacted yet
-//	2 Tracker has been contacted and is working
-//	3 Tracker is updating
-//	4 Tracker has been contacted, but it is not working (or doesn't send proper replies)
+// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
 func isTrackerStatusOK(trackers []TorrentTracker) bool {
 	for _, tracker := range trackers {
 		if tracker.Status == TrackerStatusDisabled {


### PR DESCRIPTION
## Summary

Adds `TrackerStatus` constants **5 — Tracker error** and **6 — Unreachable** so callers can match qBittorrent’s tracker `status` field without magic numbers.

## Background

qBittorrent’s tracker handling gained finer-grained endpoint states over time (e.g. work such as [#19496](https://github.com/qbittorrent/qBittorrent/pull/19496) around unreachable / endpoint-level behavior). The Web API did not always expose every distinction as its own `status` value.

**Web API 2.13.0** ([#23045](https://github.com/qbittorrent/qBittorrent/pull/23045), [changelog](https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130)) is when `torrents/trackers` started returning **5** and **6** as first-class `status` codes instead of folding those cases into **4 — Not working**.

## Changes

- `domain.go`: `TrackerStatusTrackerError` (5) and `TrackerStatusUnreachable` (6), with short inline comments on **4 / 5 / 6** explaining how they differ.
- `methods.go`: `isTrackerStatusOK` docs point at those constants instead of repeating the full status list.

No intended change to decoding behavior: `status` was already unmarshaled as an integer; this is mainly API clarity for consumers of this library.