### PR TITLE
fix: avoid recursive login check

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,58 @@
+package qbittorrent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+type authLoginCookieJar struct{}
+
+func (authLoginCookieJar) SetCookies(*url.URL, []*http.Cookie) {}
+
+func (authLoginCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	if u.Path == "/api/v2/auth/login" {
+		return nil
+	}
+
+	panic("LoginCtx checked cookies before posting auth/login")
+}
+
+func TestClient_LoginDoesNotRequireExistingCookie(t *testing.T) {
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		if r.URL.Path != "/api/v2/auth/login" {
+			t.Fatalf("path = %q, want /api/v2/auth/login", r.URL.Path)
+		}
+
+		http.SetCookie(w, &http.Cookie{Name: "SID", Value: "test-session"})
+		_, _ = w.Write([]byte("Ok."))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Host:     server.URL,
+		Username: "admin",
+		Password: "password",
+	})
+	client.http.Jar = authLoginCookieJar{}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("LoginCtx() panicked: %v", recovered)
+		}
+	}()
+
+	if err := client.LoginCtx(context.Background()); err != nil {
+		t.Fatalf("LoginCtx() error = %v", err)
+	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -20,6 +20,18 @@ func (authLoginCookieJar) Cookies(u *url.URL) []*http.Cookie {
 	panic("LoginCtx checked cookies before posting auth/login")
 }
 
+type postBasicCookieJar struct{}
+
+func (postBasicCookieJar) SetCookies(*url.URL, []*http.Cookie) {}
+
+func (postBasicCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	if u.Path == "/api/v2/transfer/info" {
+		return nil
+	}
+
+	panic("postBasicCtx checked session cookies before posting")
+}
+
 func TestClient_LoginDoesNotRequireExistingCookie(t *testing.T) {
 	requests := 0
 
@@ -51,6 +63,44 @@ func TestClient_LoginDoesNotRequireExistingCookie(t *testing.T) {
 	if err := client.LoginCtx(context.Background()); err != nil {
 		t.Fatalf("LoginCtx() error = %v", err)
 	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}
+
+func TestClient_PostBasicDoesNotCheckCookies(t *testing.T) {
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		if r.URL.Path != "/api/v2/transfer/info" {
+			t.Fatalf("path = %q, want /api/v2/transfer/info", r.URL.Path)
+		}
+
+		_, _ = w.Write([]byte("Ok."))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Host:     server.URL,
+		Username: "admin",
+		Password: "password",
+	})
+	client.http.Jar = postBasicCookieJar{}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("postBasicCtx() checked cookies: %v", recovered)
+		}
+	}()
+
+	resp, err := client.postBasicCtx(context.Background(), "transfer/info", nil)
+	if err != nil {
+		t.Fatalf("postBasicCtx() error = %v", err)
+	}
+	defer drainAndClose(resp)
 
 	if requests != 1 {
 		t.Fatalf("requests = %d, want 1", requests)

--- a/http.go
+++ b/http.go
@@ -109,7 +109,7 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	}
 	if c.usingAPIKeyAuth() {
 		c.setAPIKeyAuthHeader(req)
-	} else {
+	} else if endpoint != "auth/login" {
 		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
 		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
 			if err := c.LoginCtx(ctx); err != nil {

--- a/http.go
+++ b/http.go
@@ -88,14 +88,13 @@ func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]s
 	return resp, nil
 }
 
+// postBasicCtx should only be used for auth/login because it skips session cookie checks.
 func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
 	// add optional parameters that the user wants
 	form := url.Values{}
 	for k, v := range opts {
 		form.Add(k, v)
 	}
-
-	var resp *http.Response
 
 	reqUrl := c.buildUrl(endpoint, nil)
 
@@ -109,19 +108,12 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	}
 	if c.usingAPIKeyAuth() {
 		c.setAPIKeyAuthHeader(req)
-	} else if endpoint != "auth/login" {
-		cookieURL, _ := url.Parse(c.buildUrl("/", nil))
-		if len(c.http.Jar.Cookies(cookieURL)) == 0 {
-			if err := c.LoginCtx(ctx); err != nil {
-				return nil, errors.Wrap(err, "qbit re-login failed")
-			}
-		}
 	}
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err = c.http.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making post request: %v", reqUrl)
 	}

--- a/http.go
+++ b/http.go
@@ -106,9 +106,8 @@ func (c *Client) postBasicCtx(ctx context.Context, endpoint string, opts map[str
 	if c.cfg.BasicUser != "" && c.cfg.BasicPass != "" {
 		req.SetBasicAuth(c.cfg.BasicUser, c.cfg.BasicPass)
 	}
-	if c.usingAPIKeyAuth() {
-		c.setAPIKeyAuthHeader(req)
-	}
+
+	c.setAPIKeyAuthHeader(req)
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
Login requests currently go through the same cookie check used by authenticated API calls, so a client without an existing cookie calls LoginCtx while already trying to post auth/login and can recurse until the process crashes. This lets auth/login post directly while preserving the re-login behavior for all other calls.