### PR TITLE
fix: use enum instead of integers for share limits

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -93,6 +93,8 @@ type Torrent struct {
 	SeedingTime              int64            `json:"seeding_time"`
 	SeedingTimeLimit         int64            `json:"seeding_time_limit"`
 	InactiveSeedingTimeLimit int64            `json:"inactive_seeding_time_limit"`
+	ShareLimitAction         string           `json:"share_limit_action"`
+	ShareLimitsMode          string           `json:"share_limits_mode"`
 	SeenComplete             int64            `json:"seen_complete"`
 	SequentialDownload       bool             `json:"seq_dl"`
 	Size                     int64            `json:"size"`

--- a/filter_generated.go
+++ b/filter_generated.go
@@ -388,6 +388,24 @@ func compareInactiveSeedingTimeLimit(a, b *Torrent) int {
 	return 0
 }
 
+func compareShareLimitAction(a, b *Torrent) int {
+	if a.ShareLimitAction == b.ShareLimitAction {
+		return 0
+	} else if a.ShareLimitAction < b.ShareLimitAction {
+		return -1
+	}
+	return 1
+}
+
+func compareShareLimitsMode(a, b *Torrent) int {
+	if a.ShareLimitsMode == b.ShareLimitsMode {
+		return 0
+	} else if a.ShareLimitsMode < b.ShareLimitsMode {
+		return -1
+	}
+	return 1
+}
+
 func compareSeenComplete(a, b *Torrent) int {
 	if a.SeenComplete < b.SeenComplete {
 		return -1
@@ -569,6 +587,8 @@ var torrentComparators = map[string]func(a, b *Torrent) int{
 	"seeding_time": compareSeedingTime,
 	"seeding_time_limit": compareSeedingTimeLimit,
 	"inactive_seeding_time_limit": compareInactiveSeedingTimeLimit,
+	"share_limit_action": compareShareLimitAction,
+	"share_limits_mode": compareShareLimitsMode,
 	"seen_complete": compareSeenComplete,
 	"seq_dl": compareSequentialDownload,
 	"size": compareSize,

--- a/maindata_updaters_generated.go
+++ b/maindata_updaters_generated.go
@@ -297,6 +297,20 @@ func updateTorrentInactiveSeedingTimeLimit(val interface{}, obj *Torrent) {
 	}
 }
 
+// updateTorrentShareLimitAction updates the ShareLimitAction field of Torrent
+func updateTorrentShareLimitAction(val interface{}, obj *Torrent) {
+	if s, ok := val.(string); ok {
+		obj.ShareLimitAction = s
+	}
+}
+
+// updateTorrentShareLimitsMode updates the ShareLimitsMode field of Torrent
+func updateTorrentShareLimitsMode(val interface{}, obj *Torrent) {
+	if s, ok := val.(string); ok {
+		obj.ShareLimitsMode = s
+	}
+}
+
 // updateTorrentSeenComplete updates the SeenComplete field of Torrent
 func updateTorrentSeenComplete(val interface{}, obj *Torrent) {
 	if s, ok := val.(float64); ok {
@@ -455,6 +469,8 @@ var torrentFieldUpdaters = map[string]func(val interface{}, obj *Torrent){
 	"seeding_time": updateTorrentSeedingTime,
 	"seeding_time_limit": updateTorrentSeedingTimeLimit,
 	"inactive_seeding_time_limit": updateTorrentInactiveSeedingTimeLimit,
+	"share_limit_action": updateTorrentShareLimitAction,
+	"share_limits_mode": updateTorrentShareLimitsMode,
 	"seen_complete": updateTorrentSeenComplete,
 	"seq_dl": updateTorrentSequentialDownload,
 	"size": updateTorrentSize,

--- a/methods.go
+++ b/methods.go
@@ -2374,6 +2374,10 @@ func (c *Client) SetTorrentSuperSeedingCtx(ctx context.Context, hashes []string,
 
 // ShareLimitOptions defines share limit settings for torrents.
 // ShareLimitAction and ShareLimitsMode were added in webapi 2.12.
+//
+// ShareLimitAction and ShareLimitsMode must be Qt meta enum key names as used
+// by the WebUI (see Utils::String::toEnum in qBittorrent). Numeric strings such
+// as "0" are not recognized and are treated as Default by the server.
 type ShareLimitOptions struct {
 	RatioLimit               float64
 	SeedingTimeLimit         int64
@@ -2382,10 +2386,25 @@ type ShareLimitOptions struct {
 	ShareLimitsMode          string
 }
 
+// Share limit action names for SetTorrentShareLimit (BitTorrent::ShareLimitAction).
 const (
-	// qBittorrent default values from src/base/bittorrent/sharelimits.h.
-	shareLimitActionDefault = "-1"
-	shareLimitsModeDefault  = "-1"
+	ShareLimitActionDefault             = "Default"
+	ShareLimitActionStop                = "Stop"
+	ShareLimitActionRemove              = "Remove"
+	ShareLimitActionEnableSuperSeeding  = "EnableSuperSeeding"
+	ShareLimitActionRemoveWithContent   = "RemoveWithContent"
+)
+
+// Share limits mode names for SetTorrentShareLimit (BitTorrent::ShareLimitsMode).
+const (
+	ShareLimitsModeDefault  = "Default"
+	ShareLimitsModeMatchAny = "MatchAny"
+	ShareLimitsModeMatchAll = "MatchAll"
+)
+
+const (
+	shareLimitActionDefault = ShareLimitActionDefault
+	shareLimitsModeDefault  = ShareLimitsModeDefault
 )
 
 // SetTorrentShareLimit set share limits for torrents specified by hashes.


### PR DESCRIPTION
Disclaimer: Human failed, AI takeover.

The new share limits do not take the integer but their enum.
This PR fixes the previous behavoir.

Tested the ShareLimitAction with a supplementary main.go which change the action.
Since the native UI doesn't expose the mode (???) i have no idea how to test the library on that part...