### PR TITLE
fix(sync): expose last successful sync time separate from last attempt

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -14,18 +14,19 @@ import (
 // SyncManager manages synchronization of MainData updates and provides
 // a consistent view of the qBittorrent state across partial updates.
 type SyncManager struct {
-	mu               sync.RWMutex
-	data             *MainData
-	rid              int64
-	lastSync         time.Time
-	lastSyncDuration time.Duration
-	lastError        error
-	client           *Client
-	trackerManager   *TrackerManager
-	syncGroup        singleflight.Group
-	options          SyncOptions
-	allTorrents      []Torrent
-	resultPool       sync.Pool
+	mu                 sync.RWMutex
+	data               *MainData
+	rid                int64
+	lastSync           time.Time
+	lastSuccessfulSync time.Time
+	lastSyncDuration   time.Duration
+	lastError          error
+	client             *Client
+	trackerManager     *TrackerManager
+	syncGroup          singleflight.Group
+	options            SyncOptions
+	allTorrents        []Torrent
+	resultPool         sync.Pool
 }
 
 // SyncOptions configures the behavior of the sync manager
@@ -129,6 +130,12 @@ func (sm *SyncManager) doSync(ctx context.Context) (interface{}, error) {
 	defer func() {
 		sm.lastSyncDuration = time.Since(startTime)
 		sm.lastSync = time.Now()
+		// lastSync records every attempt (used internally to pace syncs), but
+		// lastSuccessfulSync only advances when the data actually updated, so
+		// callers can tell how fresh the cached data really is during a failure.
+		if err == nil {
+			sm.lastSuccessfulSync = sm.lastSync
+		}
 		sm.lastError = err
 		sm.mu.Unlock()
 	}()
@@ -391,12 +398,25 @@ func (sm *SyncManager) GetTagsUnchecked() []string {
 	return slices.Clone(sm.data.Tags)
 }
 
-// LastSyncTime returns the time of the last successful sync
+// LastSyncTime returns the time of the last sync attempt, whether it succeeded
+// or failed. To know how fresh the cached data actually is, use
+// LastSuccessfulSyncTime instead.
 func (sm *SyncManager) LastSyncTime() time.Time {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
 	return sm.lastSync
+}
+
+// LastSuccessfulSyncTime returns the time of the last sync that completed
+// without error. Unlike LastSyncTime it does not advance on failed syncs, so it
+// is the reliable signal for how stale the cached data has become while syncs
+// are timing out or failing.
+func (sm *SyncManager) LastSuccessfulSyncTime() time.Time {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.lastSuccessfulSync
 }
 
 // LastSyncDuration returns the duration of the last sync operation

--- a/sync_test.go
+++ b/sync_test.go
@@ -48,6 +48,13 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
+// roundTripFunc adapts a function into an http.RoundTripper so a test can drive
+// a real Client's request path (login skipped via API key auth) to a
+// deterministic success or failure without touching the network.
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
 func NewMockClient() *MockClient {
 	// Create a mock transport that returns mock responses
 	mockTransport := &mockRoundTripper{}
@@ -871,6 +878,72 @@ func TestSyncManager_LastError(t *testing.T) {
 	err = syncManager.LastError()
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected DeadlineExceeded, got %v", err)
+	}
+}
+
+// newSyncManagerWithTransport builds a SyncManager whose client uses API key
+// auth (so the request path skips login) and a single attempt (so a failing
+// request returns immediately instead of retrying), with its transport driven
+// by rt. This lets the tests exercise the real doSync path deterministically.
+func newSyncManagerWithTransport(rt roundTripFunc) *SyncManager {
+	client := NewClient(Config{Host: "http://qbit.test", APIKey: "test-key", RetryAttempts: 1})
+	client.http.Transport = rt
+	return NewSyncManager(client)
+}
+
+func TestSyncManager_LastSuccessfulSyncTimeAdvancesOnSuccess(t *testing.T) {
+	body := []byte(`{"rid":1,"full_update":true,"torrents":{},"categories":{},"tags":[],"server_state":{}}`)
+	sm := newSyncManagerWithTransport(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	before := time.Now()
+	if err := sm.Sync(context.Background()); err != nil {
+		t.Fatalf("expected a successful sync, got error: %v", err)
+	}
+
+	if got := sm.LastSuccessfulSyncTime(); got.Before(before) {
+		t.Errorf("LastSuccessfulSyncTime should advance on a successful sync: got %v, before %v", got, before)
+	}
+	if err := sm.LastError(); err != nil {
+		t.Errorf("expected no LastError after a successful sync, got %v", err)
+	}
+}
+
+// TestSyncManager_LastSuccessfulSyncTimeUnchangedOnFailure is the regression
+// guard for the bug this change fixes: lastSync is stamped on every attempt, so
+// a failed sync makes LastSyncTime() report "fresh" even though the cached data
+// did not update. LastSuccessfulSyncTime() must stay put across a failed sync so
+// callers can derive an honest data age.
+func TestSyncManager_LastSuccessfulSyncTimeUnchangedOnFailure(t *testing.T) {
+	sm := newSyncManagerWithTransport(func(req *http.Request) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	})
+
+	// Seed a prior successful sync at a clearly-old time.
+	priorSuccess := time.Now().Add(-time.Hour)
+	sm.lastSync = priorSuccess
+	sm.lastSuccessfulSync = priorSuccess
+
+	if err := sm.Sync(context.Background()); err == nil {
+		t.Fatal("expected the sync to fail")
+	}
+
+	if sm.LastError() == nil {
+		t.Error("expected LastError to be set after a failed sync")
+	}
+	// The attempt clock still advances; that is existing behavior we preserve.
+	if !sm.LastSyncTime().After(priorSuccess) {
+		t.Error("LastSyncTime (last attempted sync) should advance on a failed sync")
+	}
+	// The success clock must not move: this is the actual fix.
+	if !sm.LastSuccessfulSyncTime().Equal(priorSuccess) {
+		t.Errorf("LastSuccessfulSyncTime must not advance on a failed sync: got %v, want %v",
+			sm.LastSuccessfulSyncTime(), priorSuccess)
 	}
 }
 


### PR DESCRIPTION
`SyncManager.doSync` stamps `lastSync = time.Now()` in an unconditional `defer`, so it advances on every attempt including failed ones, even though `LastSyncTime()` is documented as "the time of the last successful sync". Any consumer that uses `LastSyncTime()` to judge how fresh the cached `MainData` is therefore reads "just synced" at exactly the moment a sync is timing out and the cached data is at its stalest. `lastError` is recorded correctly on failure, but the timestamp is not, so freshness and staleness signals built on it are wrong during an outage.

This adds a separate `lastSuccessfulSync`, advanced only when `data.Update` succeeds, exposed via a new `LastSuccessfulSyncTime()`. `lastSync` keeps its real meaning (last *attempt*, which the manager uses internally to pace syncs) and its doc comment is corrected to say so. The change is additive, so existing `LastSyncTime()` callers are unaffected and consumers that need an honest data-age signal can switch to `LastSuccessfulSyncTime()`. Surfaced while building graceful degradation for slow/saturated qBittorrent instances in autobrr/qui#2052.
