### PR TITLE
fix(sync): don't hold the manager mutex across the maindata fetch

### DIFF
--- a/maindata.go
+++ b/maindata.go
@@ -45,21 +45,28 @@ func (dest *MainData) ensureInitialized() {
 }
 
 func (dest *MainData) Update(ctx context.Context, c *Client) error {
-	source, rawData, err := c.SyncMainDataCtxWithRaw(ctx, int64(dest.Rid))
+	source, rawData, err := c.SyncMainDataCtxWithRaw(ctx, dest.Rid)
 	if err != nil {
 		return err
 	}
 
+	dest.applySync(source, rawData)
+	return nil
+}
+
+// applySync merges an already-fetched maindata response into dest. It is
+// Update without the network call, so callers can perform the fetch without
+// holding whatever lock guards dest.
+func (dest *MainData) applySync(source *MainData, rawData map[string]interface{}) {
 	// If this is a partial update (FullUpdate is false), use UpdateWithRawData
 	if !source.FullUpdate {
 		dest.UpdateWithRawData(rawData, source)
-		return nil
+		return
 	}
 
 	// For full updates, replace everything
 	*dest = *source
 	dest.ensureInitialized()
-	return nil
 }
 
 // UpdateWithRawData efficiently merges partial updates using raw JSON data

--- a/sync.go
+++ b/sync.go
@@ -122,47 +122,81 @@ func (sm *SyncManager) Sync(ctx context.Context) error {
 	return err
 }
 
-// doSync performs the actual sync operation (singleflight-compatible signature)
+// doSync performs the actual sync operation (singleflight-compatible signature).
+// Concurrent Sync callers are collapsed by the singleflight group, so doSync
+// never runs concurrently with itself and the network fetch needs no lock.
+// Keeping the mutex out of the fetch is load-bearing: holding it across the
+// round-trip parks every reader (including the *Unchecked getters) for the
+// full request duration whenever the server responds slowly.
 func (sm *SyncManager) doSync(ctx context.Context) (interface{}, error) {
 	startTime := time.Now()
-	var err error = nil
 
-	defer func() {
-		sm.lastSyncDuration = time.Since(startTime)
-		sm.lastSync = time.Now()
-		// lastSync records every attempt (used internally to pace syncs), but
-		// lastSuccessfulSync only advances when the data actually updated, so
-		// callers can tell how fresh the cached data really is during a failure.
-		if err == nil {
-			sm.lastSuccessfulSync = sm.lastSync
-		}
-		sm.lastError = err
-		sm.mu.Unlock()
-	}()
-
-	// Initialize data if needed
-	if sm.data == nil {
-		sm.data = &MainData{}
+	sm.mu.RLock()
+	var rid int64
+	if sm.data != nil {
+		rid = sm.data.Rid
 	}
+	sm.mu.RUnlock()
 
-	sm.mu.Lock()
-	if err = sm.data.Update(ctx, sm.client); err != nil {
+	source, rawData, err := sm.client.SyncMainDataCtxWithRaw(ctx, rid)
+
+	update := sm.applySyncResult(source, rawData, startTime, err)
+
+	// Callbacks run after the mutex is released so implementations can safely
+	// read back from the sync manager (the *Unchecked getters, LastError,
+	// LastSuccessfulSyncTime, ...): a callback invoked under the lock that
+	// re-entered any getter self-deadlocked on the non-reentrant RWMutex.
+	// Calling Sync (or a checked getter once data is stale) from a callback
+	// still deadlocks: it would join the singleflight call it is running in.
+	if err != nil {
 		if sm.options.OnError != nil {
 			sm.options.OnError(err)
 		}
 		return nil, err
 	}
-
-	sm.rid = sm.data.Rid
-	// Update cached torrent slice
-	sm.updateAllTorrents()
-
-	// Call update callback if set
-	if sm.options.OnUpdate != nil {
-		sm.options.OnUpdate(sm.copyMainData(sm.data))
+	if update != nil && sm.options.OnUpdate != nil {
+		sm.options.OnUpdate(update)
 	}
 
 	return nil, nil
+}
+
+// applySyncResult merges a fetched sync response and updates the sync clocks
+// under a brief write lock. It returns a deep copy of the merged data when an
+// OnUpdate callback needs to be invoked.
+func (sm *SyncManager) applySyncResult(source *MainData, rawData map[string]interface{}, startTime time.Time, syncErr error) *MainData {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	// Initialize even when the sync failed: a nil sm.data would make
+	// ensureFreshData treat every subsequent checked-getter call as a cold
+	// cache and fire an unpaced blocking sync per call against an instance
+	// that is already known to be down.
+	if sm.data == nil {
+		sm.data = &MainData{}
+	}
+
+	var update *MainData
+	if syncErr == nil {
+		sm.data.applySync(source, rawData)
+		sm.rid = sm.data.Rid
+		// Update cached torrent slice
+		sm.updateAllTorrents()
+		if sm.options.OnUpdate != nil {
+			update = sm.copyMainData(sm.data)
+		}
+	}
+
+	sm.lastSyncDuration = time.Since(startTime)
+	sm.lastSync = time.Now()
+	// lastSync records every attempt (used internally to pace syncs), but
+	// lastSuccessfulSync only advances when the data actually updated, so
+	// callers can tell how fresh the cached data really is during a failure.
+	if syncErr == nil {
+		sm.lastSuccessfulSync = sm.lastSync
+	}
+	sm.lastError = syncErr
+	return update
 }
 
 func (sm *SyncManager) updateAllTorrents() {

--- a/sync_test.go
+++ b/sync_test.go
@@ -1598,3 +1598,156 @@ func TestPeerSyncManager_ZeroSyncInterval(t *testing.T) {
 		t.Errorf("Expected SyncInterval to default to 5s when zero, got %v", psm.options.SyncInterval)
 	}
 }
+
+// TestSyncManager_ReadersNotBlockedDuringSlowSync is the regression test for
+// holding the SyncManager mutex across the maindata network round-trip: with a
+// slow qBittorrent, every getter (including the *Unchecked ones) parked behind
+// the in-flight request for its full duration, so one saturated instance
+// stalled every consumer reading through the manager.
+func TestSyncManager_ReadersNotBlockedDuringSlowSync(t *testing.T) {
+	release := make(chan struct{})
+	fetchStarted := make(chan struct{})
+	var startedOnce sync.Once
+
+	body := []byte(`{"rid":2,"full_update":true,"torrents":{},"categories":{},"tags":[],"server_state":{}}`)
+	sm := newSyncManagerWithTransport(func(req *http.Request) (*http.Response, error) {
+		startedOnce.Do(func() { close(fetchStarted) })
+		<-release // a saturated instance: the request parks until released
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	// Seed cached data so readers have something to return while the sync is in flight.
+	sm.data = &MainData{Rid: 1, Torrents: map[string]Torrent{"abc": {Hash: "abc"}}}
+	sm.updateAllTorrents()
+
+	syncDone := make(chan error, 1)
+	go func() { syncDone <- sm.Sync(context.Background()) }()
+	<-fetchStarted
+
+	readersDone := make(chan struct{})
+	go func() {
+		defer close(readersDone)
+		if got := sm.GetTorrentsUnchecked(TorrentFilterOptions{}); len(got) != 1 {
+			t.Errorf("expected the cached torrent while the sync is in flight, got %d", len(got))
+		}
+		if data := sm.GetDataUnchecked(); data == nil || data.Rid != 1 {
+			t.Error("expected the cached MainData while the sync is in flight")
+		}
+		_ = sm.LastSuccessfulSyncTime()
+	}()
+
+	select {
+	case <-readersDone:
+		// Readers returned while the network round-trip was still parked: the
+		// mutex is no longer held across the fetch.
+	case <-time.After(2 * time.Second):
+		t.Fatal("readers blocked behind an in-flight sync network round-trip")
+	}
+
+	close(release)
+	if err := <-syncDone; err != nil {
+		t.Fatalf("expected the released sync to succeed, got %v", err)
+	}
+	if data := sm.GetDataUnchecked(); data == nil || data.Rid != 2 {
+		t.Error("expected the merged sync result after release")
+	}
+}
+
+// TestSyncManager_CallbacksMayReenterSyncManager guards the callback locking
+// contract: OnUpdate and OnError run outside the manager's mutex, so a
+// callback may read back from the manager (LastSuccessfulSyncTime, getters)
+// without self-deadlocking on the non-reentrant RWMutex.
+func TestSyncManager_CallbacksMayReenterSyncManager(t *testing.T) {
+	successBody := `{"rid":1,"full_update":true,"torrents":{},"categories":{},"tags":[],"server_state":{}}`
+	var calls int
+	client := NewClient(Config{Host: "http://qbit.test", APIKey: "test-key", RetryAttempts: 1})
+	client.http.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(successBody))),
+				Header:     make(http.Header),
+			}, nil
+		}
+		return nil, context.DeadlineExceeded
+	})
+
+	var sm *SyncManager
+	reentered := make(chan string, 2)
+	opts := DefaultSyncOptions()
+	opts.OnUpdate = func(*MainData) {
+		_ = sm.LastSuccessfulSyncTime() // re-enters the manager's mutex
+		_ = sm.GetTorrentsUnchecked(TorrentFilterOptions{})
+		reentered <- "update"
+	}
+	opts.OnError = func(error) {
+		_ = sm.LastError() // re-enters the manager's mutex
+		reentered <- "error"
+	}
+	sm = NewSyncManager(client, opts)
+
+	runSync := func(wantErr bool) {
+		t.Helper()
+		errCh := make(chan error, 1)
+		go func() { errCh <- sm.Sync(context.Background()) }()
+		select {
+		case err := <-errCh:
+			if wantErr && err == nil {
+				t.Fatal("expected the sync to fail")
+			}
+			if !wantErr && err != nil {
+				t.Fatalf("expected the sync to succeed, got %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("Sync deadlocked: a callback re-entered the mutex while doSync held it")
+		}
+	}
+
+	runSync(false)
+	runSync(true)
+
+	if got := len(reentered); got != 2 {
+		t.Fatalf("expected both callbacks to have run and re-entered safely, got %d", got)
+	}
+	if first := <-reentered; first != "update" {
+		t.Errorf("expected OnUpdate to fire for the successful sync first, got %q", first)
+	}
+	if second := <-reentered; second != "error" {
+		t.Errorf("expected OnError to fire for the failed sync, got %q", second)
+	}
+}
+
+// TestSyncManager_FailedFirstSyncStillInitializesData pins failure-state
+// parity: even when the first sync fails, sm.data must be initialized so
+// (a) GetDataUnchecked returns an empty MainData rather than nil, and
+// (b) ensureFreshData paces retries by staleness instead of treating every
+// checked-getter call as a cold cache that fires an unpaced blocking sync.
+func TestSyncManager_FailedFirstSyncStillInitializesData(t *testing.T) {
+	var calls int
+	sm := newSyncManagerWithTransport(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	})
+
+	if err := sm.Sync(context.Background()); err == nil {
+		t.Fatal("expected the first sync to fail")
+	}
+
+	if data := sm.GetDataUnchecked(); data == nil {
+		t.Fatal("expected empty MainData after a failed first sync, got nil")
+	}
+
+	// Within the stale threshold (SyncInterval, default 2s) checked getters
+	// must serve the cached-empty state without firing another network sync.
+	callsAfterFailure := calls
+	_ = sm.GetTorrents(TorrentFilterOptions{})
+	_ = sm.GetData()
+	if calls != callsAfterFailure {
+		t.Fatalf("checked getters fired %d unpaced sync(s) right after a failed sync", calls-callsAfterFailure)
+	}
+}


### PR DESCRIPTION
doSync held the SyncManager write lock for the entire /sync/maindata network round-trip, so every reader (including the `*Unchecked` getters, `LastSuccessfulSyncTime`, etc.) parked behind an in-flight sync for its full duration whenever the server responded slowly. One saturated qBittorrent instance therefore stalls every consumer reading through the manager (autobrr/qui#2038, autobrr/qui#2096). Syncs are already serialized by the singleflight group, so the fetch needs no lock at all: the rid is read under a brief lock, the fetch runs unlocked, and the merge plus sync-clock stamps happen under a short write lock. The lazy `sm.data` initialization also moves under the lock (it raced readers before).

OnUpdate/OnError now run after the mutex is released, so callback implementations can safely call back into the manager without self-deadlocking on the non-reentrant RWMutex (previously any getter call from a callback deadlocked the sync loop). Regression tests cover both: readers returning while a sync round-trip is parked, and callbacks re-entering the manager; both fail against the previous locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync handling so data updates are applied more safely and consistently.
  * Prevents sync operations from blocking other reads during slow network calls.
  * Ensures callbacks can run without causing deadlocks.
  * Keeps data available after a failed sync attempt, avoiding unnecessary repeated retries.
* **Tests**
  * Added regression coverage for concurrency, callback reentrancy, and failed-sync state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->