### PR TITLE
fix(methods): send correct param name for editTracker on WebAPI 2.13+

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -1850,8 +1850,10 @@ func (c *Client) EditTracker(hash string, old, new string) error {
 // EditTrackerCtx edit tracker of torrent
 func (c *Client) EditTrackerCtx(ctx context.Context, hash string, old, new string) error {
 	opts := map[string]string{
-		"hash":    hash,
+		"hash": hash,
+		// WebAPI 2.13.0 renamed origUrl to url; send both.
 		"origUrl": old,
+		"url":     old,
 		"newUrl":  new,
 	}
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -4,8 +4,10 @@
 package qbittorrent_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -347,6 +349,50 @@ func TestClient_GetWebAPIVersion(t *testing.T) {
 	version, err := client.GetWebAPIVersion()
 	assert.NoError(t, err)
 	assert.Regexp(t, regexp.MustCompile("\\d+\\.\\d+\\.\\d+"), version)
+}
+
+func TestClient_EditTracker(t *testing.T) {
+	client := qbittorrent.NewClient(qbittorrent.Config{
+		Host:     qBittorrentBaseURL,
+		Username: qBittorrentUsername,
+		Password: qBittorrentPassword,
+	})
+
+	// Patch sampleTorrent's file/torrent name to a value unique to this run, so
+	// its info hash won't collide with sampleTorrent itself or a prior run's
+	// leftover state.
+	name := fmt.Sprintf("qbt-test-%d", time.Now().UnixNano())
+	fileName := name + ".txt"
+	torrent := strings.Replace(sampleTorrent, "12:untitled.txt", fmt.Sprintf("%d:%s", len(fileName), fileName), 1)
+	torrent = strings.Replace(torrent, "8:untitled", fmt.Sprintf("%d:%s", len(name), name), 1)
+
+	resp, err := client.AddTorrentFromMemory([]byte(torrent), nil)
+	if err != nil || len(resp.AddedTorrentIds) != 1 {
+		t.Fatalf("could not add test torrent: err=%v resp=%+v", err, resp)
+	}
+	hash := resp.AddedTorrentIds[0]
+	defer func(client *qbittorrent.Client) {
+		_ = client.DeleteTorrents([]string{hash}, false)
+	}(client)
+
+	const oldURL = "http://tracker.example.com:6969/announce"
+	const newURL = "https://tracker.example.com/announce"
+
+	err = client.AddTrackers(hash, oldURL)
+	assert.NoError(t, err)
+
+	err = client.EditTracker(hash, oldURL, newURL)
+	assert.NoError(t, err)
+
+	trackers, err := client.GetTorrentTrackers(hash)
+	assert.NoError(t, err)
+
+	var urls []string
+	for _, tr := range trackers {
+		urls = append(urls, tr.Url)
+	}
+	assert.Contains(t, urls, newURL)
+	assert.NotContains(t, urls, oldURL)
 }
 
 func TestClient_GetWebAPIVersion_IncorrectPath(t *testing.T) {


### PR DESCRIPTION
qBittorrent WebAPI 2.13.0 renamed editTracker's origUrl param to url. qbittorrent/qBittorrent#22963 Against 2.13+, the server returns 400, which reports as "new url is not a valid URL".

EditTrackerCtx now sends both parameters.

Fixes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qBittorrent tracker editing compatibility across WebAPI versions by sending the “old” tracker URL using both legacy/current parameter names, ensuring reliable replacement of the old tracker with the new one.

* **Tests**
  * Added an end-to-end integration test that uploads a temporary torrent, edits an “old” tracker URL to a “new” URL, and verifies the change is reflected (new present, old absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->