### PR TITLE
feat(sync): add tracker map accessors

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -413,6 +413,26 @@ func (sm *SyncManager) GetCategoriesUnchecked() map[string]Category {
 	return maps.Clone(sm.data.Categories)
 }
 
+// GetTrackers returns a copy of the tracker URL to torrent hashes map
+func (sm *SyncManager) GetTrackers() map[string][]string {
+	sm.ensureFreshData()
+	return sm.GetTrackersUnchecked()
+}
+
+// GetTrackersUnchecked returns a copy of the tracker URL to torrent hashes map
+// without checking freshness. This is faster but may return stale data.
+// The hash slices alias the cached data; callers must not modify them.
+func (sm *SyncManager) GetTrackersUnchecked() map[string][]string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	if sm.data == nil {
+		return nil
+	}
+
+	return maps.Clone(sm.data.Trackers)
+}
+
 // GetTags returns a copy of all tags
 func (sm *SyncManager) GetTags() []string {
 	sm.ensureFreshData()

--- a/sync.go
+++ b/sync.go
@@ -413,7 +413,8 @@ func (sm *SyncManager) GetCategoriesUnchecked() map[string]Category {
 	return maps.Clone(sm.data.Categories)
 }
 
-// GetTrackers returns a copy of the tracker URL to torrent hashes map
+// GetTrackers returns a copy of the tracker URL to torrent hashes map.
+// The hash slices alias the cached data; callers must not modify them.
 func (sm *SyncManager) GetTrackers() map[string][]string {
 	sm.ensureFreshData()
 	return sm.GetTrackersUnchecked()

--- a/sync_test.go
+++ b/sync_test.go
@@ -634,6 +634,27 @@ func TestSyncManager_CopyMainData(t *testing.T) {
 	}
 }
 
+func TestSyncManager_GetTrackersUnchecked(t *testing.T) {
+	sm := &SyncManager{}
+
+	if trackers := sm.GetTrackersUnchecked(); trackers != nil {
+		t.Error("Expected nil trackers when not initialized")
+	}
+
+	sm.data = &MainData{
+		Trackers: map[string][]string{
+			"http://tracker.example.invalid/announce": {"abc123"},
+		},
+	}
+
+	// Mutating the result must not reach sm.data, which the sync loop writes.
+	trackers := sm.GetTrackersUnchecked()
+	trackers["http://other.example.invalid/announce"] = []string{"def456"}
+	if len(sm.data.Trackers) != 1 {
+		t.Error("Modifying returned map affected cached data")
+	}
+}
+
 func TestSyncManager_DynamicSync(t *testing.T) {
 	client := NewClient(Config{Host: "http://localhost:8080"})
 	options := SyncOptions{


### PR DESCRIPTION
`GetData` and `GetDataUnchecked` return a deep copy of the whole `MainData`, which includes one entry per torrent. A consumer that needs only the tracker map pays that cost on every read. In a 60 second idle profile of a live qui instance the clone accounted for 497.93 MB/min, 26.9% of everything the process allocated.

`GetTrackers` and `GetTrackersUnchecked` mirror the existing `GetCategories` pair and clone the tracker map only. That map holds one entry per tracker URL and shares its hash slices, so the cost scales with tracker count instead of torrent count.

`copyMainData` is unchanged. Callers that read `MainData.Torrents` still need the deep copy, because `applySync` writes into the cached map under the write lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessors for retrieving cached tracker and torrent-hash mappings.
  * Added a refreshed access option that ensures stale data is updated before retrieval.
  * Added a lightweight option for checking cached data without triggering a refresh.
  * Returned mappings can be safely inspected without altering the cached tracker data.
* **Tests**
  * Added coverage for empty-state handling and safe map isolation when retrieving cached mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->