### PR TITLE
feat(torrent): expose metadata availability

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -74,6 +74,7 @@ type Torrent struct {
 	FirstLastPiecePrio       bool             `json:"f_l_piece_prio"`
 	ForceStart               bool             `json:"force_start"`
 	Hash                     string           `json:"hash"`
+	HasMetadata              *bool            `json:"has_metadata"`
 	InfohashV1               string           `json:"infohash_v1"`
 	InfohashV2               string           `json:"infohash_v2"`
 	Popularity               float64          `json:"popularity"`

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,10 +1,40 @@
 package qbittorrent
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTorrentHasMetadataJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		json string
+		want *bool
+	}{
+		{name: "available", json: `{"has_metadata":true}`, want: ptr(true)},
+		{name: "unavailable", json: `{"has_metadata":false}`, want: ptr(false)},
+		{name: "unsupported", json: `{}`, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var torrent Torrent
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &torrent))
+			assert.Equal(t, tt.want, torrent.HasMetadata)
+		})
+	}
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}
 
 func TestTorrentAddOptions_Prepare(t *testing.T) {
 	type fields struct {

--- a/internal/codegen/generate_maindata_updaters.go
+++ b/internal/codegen/generate_maindata_updaters.go
@@ -152,6 +152,8 @@ func getGoType(expr ast.Expr) string {
 		return "[]" + getGoType(t.Elt)
 	case *ast.MapType:
 		return "map[" + getGoType(t.Key) + "]" + getGoType(t.Value)
+	case *ast.StarExpr:
+		return "*" + getGoType(t.X)
 	}
 	return "interface{}"
 }
@@ -233,6 +235,10 @@ func generateFieldUpdateLogic(structName string, field FieldInfo) {
 	case "bool":
 		fmt.Printf("\tif %s, ok := val.(bool); ok {\n", strings.ToLower(field.Name[:1]))
 		fmt.Printf("\t\tobj.%s = %s\n", field.Name, strings.ToLower(field.Name[:1]))
+		fmt.Printf("\t}\n")
+	case "*bool":
+		fmt.Printf("\tif %s, ok := val.(bool); ok {\n", strings.ToLower(field.Name[:1]))
+		fmt.Printf("\t\tobj.%s = &%s\n", field.Name, strings.ToLower(field.Name[:1]))
 		fmt.Printf("\t}\n")
 	case "TorrentState":
 		fmt.Printf("\tif %s, ok := val.(string); ok {\n", strings.ToLower(field.Name[:1]))

--- a/maindata_updaters_generated.go
+++ b/maindata_updaters_generated.go
@@ -136,6 +136,13 @@ func updateTorrentHash(val interface{}, obj *Torrent) {
 	}
 }
 
+// updateTorrentHasMetadata updates the HasMetadata field of Torrent
+func updateTorrentHasMetadata(val interface{}, obj *Torrent) {
+	if h, ok := val.(bool); ok {
+		obj.HasMetadata = &h
+	}
+}
+
 // updateTorrentInfohashV1 updates the InfohashV1 field of Torrent
 func updateTorrentInfohashV1(val interface{}, obj *Torrent) {
 	if i, ok := val.(string); ok {
@@ -446,6 +453,7 @@ var torrentFieldUpdaters = map[string]func(val interface{}, obj *Torrent){
 	"f_l_piece_prio": updateTorrentFirstLastPiecePrio,
 	"force_start": updateTorrentForceStart,
 	"hash": updateTorrentHash,
+	"has_metadata": updateTorrentHasMetadata,
 	"infohash_v1": updateTorrentInfohashV1,
 	"infohash_v2": updateTorrentInfohashV2,
 	"popularity": updateTorrentPopularity,

--- a/sync_test.go
+++ b/sync_test.go
@@ -349,13 +349,14 @@ func TestMergeTorrents(t *testing.T) {
 
 	// Add an existing torrent
 	existing := Torrent{
-		Hash:     "abc123",
-		Name:     "Test Torrent",
-		Progress: 0.5,
-		DlSpeed:  1000,
-		UpSpeed:  500,
-		State:    "downloading",
-		Category: "test",
+		Hash:        "abc123",
+		HasMetadata: ptr(true),
+		Name:        "Test Torrent",
+		Progress:    0.5,
+		DlSpeed:     1000,
+		UpSpeed:     500,
+		State:       "downloading",
+		Category:    "test",
 	}
 	sm.data.Torrents["abc123"] = existing
 
@@ -363,9 +364,10 @@ func TestMergeTorrents(t *testing.T) {
 	rawData := map[string]interface{}{
 		"torrents": map[string]interface{}{
 			"abc123": map[string]interface{}{
-				"progress": 0.75,
-				"dlspeed":  float64(1500),
-				"state":    "downloading",
+				"progress":     0.75,
+				"dlspeed":      float64(1500),
+				"state":        "downloading",
+				"has_metadata": false,
 				// Note: upspeed, category, etc. are NOT present in this update
 			},
 		},
@@ -402,6 +404,9 @@ func TestMergeTorrents(t *testing.T) {
 
 	if merged.Category != "test" {
 		t.Errorf("Expected category preserved, got %s", merged.Category)
+	}
+	if merged.HasMetadata == nil || *merged.HasMetadata {
+		t.Fatalf("Expected has_metadata false, got %v", merged.HasMetadata)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Expose qBittorrent's optional `has_metadata` field on torrents.
- Retain `has_metadata` when present in sync updates.
- Update the sync updater generator to support optional booleans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added torrent metadata availability information, including support for true, false, and unknown states.
  * Torrent updates can now modify the metadata availability value.

* **Bug Fixes**
  * Ensured explicit false metadata values are preserved when merging torrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->