### PR TITLE
fix(sync): prevent concurrent maindata map access

### DIFF
--- a/maindata.go
+++ b/maindata.go
@@ -15,19 +15,6 @@ func normalizeHashes(dest map[string]Torrent) {
 	}
 }
 
-// normalizeHashesRaw normalizes hashes in raw JSON data format
-func normalizeHashesRaw(rawData map[string]interface{}) {
-	if torrentsRaw, exists := rawData["torrents"]; exists {
-		if torrentsMap, ok := torrentsRaw.(map[string]interface{}); ok {
-			for hash, torrentRaw := range torrentsMap {
-				if torrentMap, ok := torrentRaw.(map[string]interface{}); ok {
-					torrentMap["hash"] = hash
-				}
-			}
-		}
-	}
-}
-
 // ensureInitialized prepares MainData maps/slices so merge helpers can write safely.
 func (dest *MainData) ensureInitialized() {
 	if dest.Torrents == nil {
@@ -135,11 +122,10 @@ func (dest *MainData) mergeTorrentsPartial(torrentsMap map[string]interface{}) {
 
 		existing, exists := dest.Torrents[hash]
 		if !exists {
-			// New torrent - create a minimal torrent with the hash at least
-			existing = Torrent{Hash: hash}
+			existing = Torrent{}
 		}
 
-		// Always start with existing data and update only provided fields
+		existing.Hash = hash
 		updateTorrentFields(&existing, updateMap)
 
 		dest.Torrents[hash] = existing

--- a/maindata_test.go
+++ b/maindata_test.go
@@ -1,0 +1,61 @@
+package qbittorrent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeMainData(t *testing.T) {
+	body := strings.NewReader(`{"rid":1,"torrents":{"abc":{"name":"test"}}}`)
+
+	data, raw, err := decodeMainData(body)
+	if err != nil {
+		t.Fatalf("decode main data: %v", err)
+	}
+
+	if got := data.Torrents["abc"].Hash; got != "abc" {
+		t.Errorf("typed torrent hash = %q, want %q", got, "abc")
+	}
+
+	torrents, ok := raw["torrents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("raw torrents has type %T", raw["torrents"])
+	}
+	torrent, ok := torrents["abc"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("raw torrent has type %T", torrents["abc"])
+	}
+	if _, exists := torrent["hash"]; exists {
+		t.Error("raw torrent hash should not be synthesized")
+	}
+}
+
+func TestDecodeMainDataError(t *testing.T) {
+	data, raw, err := decodeMainData(strings.NewReader(`{"rid":"invalid"}`))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if data != nil || raw != nil {
+		t.Fatalf("decode error returned data=%v raw=%v", data, raw)
+	}
+}
+
+func TestMergeTorrentsPartialUsesMapKeyAsHash(t *testing.T) {
+	dest := MainData{
+		Torrents: map[string]Torrent{
+			"abc": {Hash: "stale", Name: "old"},
+		},
+	}
+
+	dest.mergeTorrentsPartial(map[string]interface{}{
+		"abc": map[string]interface{}{"name": "new"},
+	})
+
+	got := dest.Torrents["abc"]
+	if got.Hash != "abc" {
+		t.Errorf("torrent hash = %q, want %q", got.Hash, "abc")
+	}
+	if got.Name != "new" {
+		t.Errorf("torrent name = %q, want %q", got.Name, "new")
+	}
+}

--- a/methods.go
+++ b/methods.go
@@ -993,32 +993,37 @@ func (c *Client) SyncMainDataCtxWithRaw(ctx context.Context, rid int64) (*MainDa
 		return nil, nil, errors.Wrap(ErrUnexpectedStatus, "could not get main data; status code: %d", resp.StatusCode)
 	}
 
+	return decodeMainData(resp.Body)
+}
+
+func decodeMainData(body io.Reader) (*MainData, map[string]interface{}, error) {
 	rp, wp := io.Pipe()
+	rawDone := make(chan error, 1)
+
 	var rawData map[string]interface{}
-	var mapErr error
 	go func() {
-		defer wp.Close()
-		mapErr = json.NewDecoder(io.TeeReader(resp.Body, wp)).Decode(&rawData)
-		if mapErr == nil {
-			normalizeHashesRaw(rawData)
-		}
+		err := json.NewDecoder(io.TeeReader(body, wp)).Decode(&rawData)
+		_ = wp.CloseWithError(err)
+		rawDone <- err
 	}()
 
-	// Then decode into structured MainData
 	var info MainData
-	if err := json.NewDecoder(rp).Decode(&info); err != nil {
-		return nil, nil, errors.Wrap(err, "could not unmarshal body")
+	typedErr := json.NewDecoder(rp).Decode(&info)
+	if typedErr != nil {
+		// Unblock the raw decoder if the structured decoder stops reading.
+		_ = rp.CloseWithError(typedErr)
 	}
 
-	io.Copy(io.Discard, rp)
-
-	if mapErr != nil {
-		return nil, nil, errors.Wrap(mapErr, "could not unmarshal body to map")
+	rawErr := <-rawDone
+	if typedErr != nil {
+		return nil, nil, errors.Wrap(typedErr, "could not unmarshal body")
+	}
+	if rawErr != nil {
+		return nil, nil, errors.Wrap(rawErr, "could not unmarshal body to map")
 	}
 
 	normalizeHashes(info.Torrents)
 	return &info, rawData, nil
-
 }
 
 func (c *Client) Pause(hashes []string) error {

--- a/sync_test.go
+++ b/sync_test.go
@@ -420,7 +420,6 @@ func TestMergeTorrents_NewTorrent(t *testing.T) {
 	rawData := map[string]interface{}{
 		"torrents": map[string]interface{}{
 			"def456": map[string]interface{}{
-				"hash":     "def456",
 				"name":     "New Torrent",
 				"progress": 0.25,
 				"dlspeed":  float64(2000),
@@ -446,6 +445,9 @@ func TestMergeTorrents_NewTorrent(t *testing.T) {
 	newTorrent, exists := sm.data.Torrents["def456"]
 	if !exists {
 		t.Fatal("Expected new torrent def456 to exist")
+	}
+	if newTorrent.Hash != "def456" {
+		t.Errorf("Expected hash 'def456', got %q", newTorrent.Hash)
 	}
 
 	if newTorrent.Name != "New Torrent" {


### PR DESCRIPTION
SyncMainDataCtxWithRaw could return while its raw decoder goroutine was still updating rawData and mapErr. Callers could observe partially decoded data, trigger concurrent map read and write panics, or report a data race. A structured decode error could also leave the producer blocked writing to the abandoned pipe.

Join the producer before inspecting its error or returning either representation, and close the pipe reader when structured decoding fails. Stop mutating nested raw torrent maps and derive torrent hashes from their map keys during partial merges.

This retains streaming decoding and avoids buffering potentially large responses while ensuring all returned data is stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization and decoding of torrent data.
  * Preserved raw torrent records without adding synthesized hash values.
  * Ensured newly merged torrents correctly receive their hash from the source data.
  * Improved handling of decoding errors to prevent stalled synchronization.

* **Tests**
  * Added coverage for data decoding, error handling, raw-data preservation, and partial torrent merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->