### PR TITLE
fix: preserve client behavior on qBittorrent 5.3

### DIFF
--- a/compatibility_test.go
+++ b/compatibility_test.go
@@ -1,0 +1,268 @@
+package qbittorrent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newCompatibilityClient(handler http.HandlerFunc) *Client {
+	return NewClient(Config{Host: "http://qbittorrent.test", APIKey: "fixture"}).WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			return recorder.Result(), nil
+		}),
+	})
+}
+
+func TestAddTorrentSeedModeCompatibility(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "fixture.torrent")
+	require.NoError(t, os.WriteFile(file, []byte("fixture"), 0o600))
+	methods := []struct {
+		name string
+		add  func(context.Context, *Client, map[string]string) (*TorrentAddResponse, error)
+	}{
+		{"memory", func(_ context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromMemory([]byte("fixture"), opts)
+		}},
+		{"memory context", func(ctx context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromMemoryCtx(ctx, []byte("fixture"), opts)
+		}},
+		{"batch memory", func(_ context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentsFromMemory([][]byte{[]byte("fixture"), []byte("fixture")}, opts)
+		}},
+		{"batch memory context", func(ctx context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentsFromMemoryCtx(ctx, [][]byte{[]byte("fixture"), []byte("fixture")}, opts)
+		}},
+		{"file", func(_ context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromFile(file, opts)
+		}},
+		{"file context", func(ctx context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromFileCtx(ctx, file, opts)
+		}},
+		{"URL", func(_ context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromUrl("https://example.invalid/fixture.torrent", opts)
+		}},
+		{"URL context", func(ctx context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentFromUrlCtx(ctx, "https://example.invalid/fixture.torrent", opts)
+		}},
+		{"batch URL context", func(ctx context.Context, c *Client, opts map[string]string) (*TorrentAddResponse, error) {
+			return c.AddTorrentsFromUrlsCtx(ctx, []string{"https://example.invalid/fixture.torrent", "https://example.invalid/second.torrent"}, opts)
+		}},
+	}
+
+	for _, method := range methods {
+		for _, tc := range []struct {
+			name string
+			opts map[string]string
+			want string
+		}{
+			{"typed true", (&TorrentAddOptions{SkipHashCheck: true}).Prepare(), "true"},
+			{"typed false", (&TorrentAddOptions{SkipHashCheck: false}).Prepare(), ""},
+			{"legacy true", map[string]string{"skip_checking": "true"}, "true"},
+			{"legacy false", map[string]string{"skip_checking": "false"}, "false"},
+			{"new true", map[string]string{"seedMode": "true"}, "true"},
+			{"new false", map[string]string{"seedMode": "false"}, "false"},
+			{"new true wins", map[string]string{"seedMode": "true", "skip_checking": "false"}, "true"},
+			{"new false wins", map[string]string{"seedMode": "false", "skip_checking": "true"}, "false"},
+			{"absent", map[string]string{"category": "fixture"}, ""},
+			{"nil", nil, ""},
+		} {
+			t.Run(method.name+"/"+tc.name, func(t *testing.T) {
+				calls := 0
+				client := newCompatibilityClient(func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					require.Equal(t, http.MethodPost, r.Method)
+					require.Equal(t, "/api/v2/torrents/add", r.URL.Path)
+					if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/") {
+						require.NoError(t, r.ParseMultipartForm(1<<20))
+						defer r.MultipartForm.RemoveAll()
+						require.NotEmpty(t, r.MultipartForm.File["torrents"])
+					} else {
+						require.NoError(t, r.ParseForm())
+						require.Contains(t, r.Form.Get("urls"), "https://example.invalid/fixture.torrent")
+					}
+					// 5.2.2 reads skip_checking. 5.3 reads seedMode.
+					for _, key := range []string{"skip_checking", "seedMode"} {
+						require.Equal(t, tc.want, r.Form.Get(key))
+						require.Equal(t, tc.want != "", r.Form.Has(key))
+					}
+					w.Header().Set("Content-Type", "text/plain")
+					_, _ = w.Write([]byte("Ok."))
+				})
+				before := maps.Clone(tc.opts)
+				_, err := method.add(t.Context(), client, tc.opts)
+				require.NoError(t, err)
+				require.Equal(t, before, tc.opts)
+				require.Equal(t, 1, calls)
+
+				if tc.name == "legacy true" {
+					delete(tc.opts, "skip_checking")
+					tc.want = ""
+					_, err = method.add(t.Context(), client, tc.opts)
+					require.NoError(t, err)
+					require.Empty(t, tc.opts)
+					require.Equal(t, 2, calls)
+				}
+			})
+		}
+	}
+}
+
+func TestRSSRuleSeedModeCompatibility(t *testing.T) {
+	for _, tc := range []struct {
+		seed string
+		want bool
+	}{
+		{`"skip_checking":true`, true},
+		{`"skip_checking":false`, false},
+		{`"seed_mode":true`, true},
+		{`"seed_mode":false`, false},
+		{`"seed_mode":false,"skip_checking":true`, false},
+		{`"seed_mode":true,"skip_checking":false`, true},
+	} {
+		for _, mode := range []string{"Default", "MatchAny", "MatchAll"} {
+			t.Run(tc.seed+"/"+mode, func(t *testing.T) {
+				want := tc.want
+				writes := 0
+				client := newCompatibilityClient(func(w http.ResponseWriter, r *http.Request) {
+					switch r.Method + " " + r.URL.Path {
+					case "GET /api/v2/rss/rules":
+						_, _ = fmt.Fprintf(w, `{"fixture":{"priority":1,"torrentParams":{%s,"share_limits_mode":%q,"category":"tv"}}}`, tc.seed, mode)
+					case "POST /api/v2/rss/setRule":
+						writes++
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "fixture", r.Form.Get("ruleName"))
+						var wire struct {
+							Priority int            `json:"priority"`
+							Params   map[string]any `json:"torrentParams"`
+						}
+						require.NoError(t, json.Unmarshal([]byte(r.Form.Get("ruleDef")), &wire))
+						require.Equal(t, 2, wire.Priority)
+						require.Equal(t, "tv", wire.Params["category"])
+						require.Equal(t, mode, wire.Params["share_limits_mode"])
+						require.Equal(t, want, wire.Params["seed_mode"])
+						require.Equal(t, want, wire.Params["skip_checking"])
+					default:
+						t.Fatalf("unexpected request: %s %s", r.Method, r.URL)
+					}
+				})
+				rules, err := client.GetRSSRulesCtx(t.Context())
+				require.NoError(t, err)
+				rule := rules["fixture"]
+				require.NotNil(t, rule.TorrentParams)
+				require.Equal(t, tc.want, rule.TorrentParams.SkipChecking)
+				rule.Priority = 2
+				require.NoError(t, client.SetRSSRuleCtx(t.Context(), "fixture", rule))
+				// The existing public field must still control later edits.
+				want = !want
+				rule.TorrentParams.SkipChecking = want
+				require.NoError(t, client.SetRSSRule("fixture", rule))
+				require.Equal(t, 2, writes)
+			})
+		}
+	}
+}
+
+func TestTorrentCreationDateCompatibility(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want [3]string
+		bad  bool
+	}{
+		{"legacy", `"timeAdded":"Mon Sep 7 08:00:00 2026","timeStarted":"Mon Sep 7 08:00:01 2026","timeFinished":"Mon Sep 7 08:00:02 2026"`, [3]string{"Mon Sep 7 08:00:00 2026", "Mon Sep 7 08:00:01 2026", "Mon Sep 7 08:00:02 2026"}, false},
+		{"numeric", `"timeAdded":0,"timeStarted":1,"timeFinished":2`, [3]string{"1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"}, false},
+		{"optional dates omitted", `"timeAdded":-1`, [3]string{"1969-12-31T23:59:59Z", "", ""}, false},
+		{"mixed", `"timeAdded":"Mon Sep 7 08:00:00 2026","timeStarted":2147483648`, [3]string{"Mon Sep 7 08:00:00 2026", "2038-01-19T03:14:08Z", ""}, false},
+		{"object", `"timeAdded":{}`, [3]string{}, true},
+		{"boolean", `"timeStarted":true`, [3]string{}, true},
+		{"fraction", `"timeFinished":1.5`, [3]string{}, true},
+		{"null", `"timeAdded":null`, [3]string{}, true},
+		{"overflow", `"timeAdded":9223372036854775808`, [3]string{}, true},
+		{"out of date range", `"timeAdded":9223372036854775807`, [3]string{}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newCompatibilityClient(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				switch r.URL.Path {
+				case "/api/v2/app/webapiVersion":
+					_, _ = w.Write([]byte("2.16.2"))
+				case "/api/v2/torrentcreator/status":
+					require.Equal(t, "fixture", r.URL.Query().Get("taskID"))
+					_, _ = fmt.Fprintf(w, `[{"taskID":"fixture","status":"Finished",%s}]`, tc.body)
+				default:
+					t.Fatalf("unexpected request: %s", r.URL)
+				}
+			})
+			tasks, err := client.GetTorrentCreationStatusCtx(t.Context(), "fixture")
+			if tc.bad {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, tasks, 1)
+			require.Equal(t, "fixture", tasks[0].TaskID)
+			require.Equal(t, TorrentCreationStatusFinished, tasks[0].Status)
+			require.Equal(t, tc.want, [3]string{tasks[0].TimeAdded, tasks[0].TimeStarted, tasks[0].TimeFinished})
+		})
+	}
+}
+
+func TestAppPreferencesCompatibility(t *testing.T) {
+	type testCase struct {
+		name string
+		body string
+		want AppPreferences
+	}
+	cases := []testCase{
+		{"legacy", `{"mail_notification_ssl_enabled":true,"export_dir":"/old","export_dir_fin":"/finished"}`, AppPreferences{
+			MailNotificationSslEnabled: true, ExportDir: "/old", ExportDirFin: "/finished",
+		}},
+		{"mixed and false", `{"mail_notification_ssl_enabled":true,"mail_notification_encryption_type":"None","torrent_files_backup_enabled":false,"torrent_files_finished_backup_dir_enabled":false,"remove_torrent_file_backup":false,"queueing_enabled":true}`, AppPreferences{
+			MailNotificationSslEnabled: true, MailNotificationEncryptionType: "None", QueueingEnabled: true,
+		}},
+	}
+	for _, encryption := range []string{"None", "STARTTLS", "SMTPS"} {
+		cases = append(cases, testCase{encryption, fmt.Sprintf(`{"mail_notification_encryption_type":%q,"torrent_files_backup_enabled":true,"torrent_files_backup_dir":"/backup","torrent_files_finished_backup_dir_enabled":true,"torrent_files_finished_backup_dir":"/finished","remove_torrent_file_backup":true}`, encryption), AppPreferences{
+			MailNotificationEncryptionType: encryption,
+			TorrentFilesBackupEnabled:      true, TorrentFilesBackupDir: "/backup",
+			TorrentFilesFinishedBackupDirEnabled: true, TorrentFilesFinishedBackupDir: "/finished",
+			RemoveTorrentFileBackup: true,
+		}})
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writes := 0
+			client := newCompatibilityClient(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method + " " + r.URL.Path {
+				case "GET /api/v2/app/preferences":
+					_, _ = w.Write([]byte(tc.body))
+				case "POST /api/v2/app/setPreferences":
+					writes++
+					require.NoError(t, r.ParseForm())
+					require.JSONEq(t, tc.body, r.Form.Get("json"))
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL)
+				}
+			})
+			prefs, err := client.GetAppPreferencesCtx(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, prefs)
+			var write map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &write))
+			require.NoError(t, client.SetPreferencesCtx(t.Context(), write))
+			require.Equal(t, 1, writes)
+		})
+	}
+}

--- a/compatibility_test.go
+++ b/compatibility_test.go
@@ -183,7 +183,7 @@ func TestTorrentCreationDateCompatibility(t *testing.T) {
 	}{
 		{"legacy", `"timeAdded":"Mon Sep 7 08:00:00 2026","timeStarted":"Mon Sep 7 08:00:01 2026","timeFinished":"Mon Sep 7 08:00:02 2026"`, [3]string{"Mon Sep 7 08:00:00 2026", "Mon Sep 7 08:00:01 2026", "Mon Sep 7 08:00:02 2026"}, false},
 		{"numeric", `"timeAdded":0,"timeStarted":1,"timeFinished":2`, [3]string{"1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"}, false},
-		{"optional dates omitted", `"timeAdded":-1`, [3]string{"1969-12-31T23:59:59Z", "", ""}, false},
+		{"optional dates omitted", `"timeAdded":-1`, [3]string{"", "", ""}, false},
 		{"mixed", `"timeAdded":"Mon Sep 7 08:00:00 2026","timeStarted":2147483648`, [3]string{"Mon Sep 7 08:00:00 2026", "2038-01-19T03:14:08Z", ""}, false},
 		{"object", `"timeAdded":{}`, [3]string{}, true},
 		{"boolean", `"timeStarted":true`, [3]string{}, true},

--- a/domain.go
+++ b/domain.go
@@ -3,6 +3,7 @@ package qbittorrent
 import (
 	"encoding/json"
 	"strconv"
+	"time"
 
 	"github.com/autobrr/go-qbittorrent/errors"
 )
@@ -714,6 +715,14 @@ type AppPreferences struct {
 	WebUIUpnp                          bool             `json:"web_ui_upnp"`
 	WebUIUseCustomHTTPHeadersEnabled   bool             `json:"web_ui_use_custom_http_headers_enabled"`
 	WebUIUsername                      string           `json:"web_ui_username"`
+
+	// qBittorrent 5.3 preferences.
+	MailNotificationEncryptionType       string `json:"mail_notification_encryption_type"` // None, STARTTLS, or SMTPS
+	RemoveTorrentFileBackup              bool   `json:"remove_torrent_file_backup"`
+	TorrentFilesBackupEnabled            bool   `json:"torrent_files_backup_enabled"`
+	TorrentFilesBackupDir                string `json:"torrent_files_backup_dir"`
+	TorrentFilesFinishedBackupDirEnabled bool   `json:"torrent_files_finished_backup_dir_enabled"`
+	TorrentFilesFinishedBackupDir        string `json:"torrent_files_finished_backup_dir"`
 }
 
 type MainData struct {
@@ -913,7 +922,8 @@ type TorrentCreationParams struct {
 	StartSeeding        *bool         `json:"startSeeding,omitempty"` // nil = default (true), false = don't seed, true = seed
 }
 
-// TorrentCreationTask represents a torrent creation task
+// TorrentCreationTask represents a torrent creation task.
+// Dates retain legacy strings. Numeric Unix seconds become UTC RFC3339 strings.
 type TorrentCreationTask struct {
 	TaskID              string                `json:"taskID"`
 	SourcePath          string                `json:"sourcePath"`
@@ -933,6 +943,41 @@ type TorrentCreationTask struct {
 	TimeFinished        string                `json:"timeFinished,omitempty"`
 	Progress            float64               `json:"progress,omitempty"`
 	ErrorMessage        string                `json:"errorMessage,omitempty"`
+}
+
+func (t *TorrentCreationTask) UnmarshalJSON(data []byte) error {
+	type task TorrentCreationTask
+	wire := struct {
+		*task
+		TimeAdded    torrentCreationTime `json:"timeAdded"`
+		TimeStarted  torrentCreationTime `json:"timeStarted"`
+		TimeFinished torrentCreationTime `json:"timeFinished"`
+	}{task: (*task)(t)}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	t.TimeAdded = string(wire.TimeAdded)
+	t.TimeStarted = string(wire.TimeStarted)
+	t.TimeFinished = string(wire.TimeFinished)
+	return nil
+}
+
+type torrentCreationTime string
+
+func (t *torrentCreationTime) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, (*string)(t))
+	}
+	seconds, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid torrent creation date")
+	}
+	date := time.Unix(seconds, 0).UTC()
+	if date.Year() < 0 || date.Year() > 9999 {
+		return errors.New("torrent creation date is outside the RFC3339 range")
+	}
+	*t = torrentCreationTime(date.Format(time.RFC3339))
+	return nil
 }
 
 // TorrentCreationTaskResponse represents the response when adding a torrent creation task

--- a/domain.go
+++ b/domain.go
@@ -972,6 +972,11 @@ func (t *torrentCreationTime) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "invalid torrent creation date")
 	}
+	if seconds < 0 {
+		// qBittorrent sends -1 when the task has no valid date.
+		*t = ""
+		return nil
+	}
 	date := time.Unix(seconds, 0).UTC()
 	if date.Year() < 0 || date.Year() > 9999 {
 		return errors.New("torrent creation date is outside the RFC3339 range")

--- a/http.go
+++ b/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"maps"
 	"math/rand"
 	"mime/multipart"
 	"net"
@@ -49,6 +50,7 @@ func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]st
 }
 
 func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
+	opts = normalizeAddOptions(endpoint, opts)
 	// add optional parameters that the user wants
 	form := url.Values{}
 	for k, v := range opts {
@@ -164,6 +166,7 @@ func buildMultiFileForm(files [][]byte, opts map[string]string) (*bytes.Buffer, 
 // postMultiMemoryCtx sends multiple torrent files in a single multipart request.
 // qBittorrent supports multiple "torrents" form fields in one request.
 func (c *Client) postMultiMemoryCtx(ctx context.Context, endpoint string, files [][]byte, opts map[string]string) (*http.Response, error) {
+	opts = normalizeAddOptions(endpoint, opts)
 	body, contentType, err := buildMultiFileForm(files, opts)
 	if err != nil {
 		return nil, err
@@ -200,6 +203,7 @@ func (c *Client) postMultiMemoryCtx(ctx context.Context, endpoint string, files 
 }
 
 func (c *Client) postReaderCtx(ctx context.Context, endpoint string, reader io.Reader, opts map[string]string) (*http.Response, error) {
+	opts = normalizeAddOptions(endpoint, opts)
 	// Buffer to store our request body as bytes
 	var requestBody bytes.Buffer
 
@@ -263,6 +267,24 @@ func (c *Client) postReaderCtx(ctx context.Context, endpoint string, reader io.R
 	}
 
 	return resp, nil
+}
+
+// normalizeAddOptions sends matching seed-mode aliases for old and new servers.
+func normalizeAddOptions(endpoint string, opts map[string]string) map[string]string {
+	if endpoint != "torrents/add" {
+		return opts
+	}
+	seedMode, ok := opts["seedMode"]
+	if !ok {
+		seedMode, ok = opts["skip_checking"]
+	}
+	if !ok {
+		return opts
+	}
+	opts = maps.Clone(opts)
+	opts["seedMode"] = seedMode
+	opts["skip_checking"] = seedMode
+	return opts
 }
 
 func generateTorrentName() string {

--- a/methods.go
+++ b/methods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -775,9 +776,11 @@ func (c *Client) AddTorrentFromUrlCtx(ctx context.Context, url string, options m
 		return nil, ErrNoTorrentURLProvided
 	}
 
-	options["urls"] = url
+	form := make(map[string]string, len(options)+1)
+	maps.Copy(form, options)
+	form["urls"] = url
 
-	resp, err := c.postCtx(ctx, "torrents/add", options)
+	resp, err := c.postCtx(ctx, "torrents/add", form)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not add torrent; url: %v", url)
 	}
@@ -818,9 +821,11 @@ func (c *Client) AddTorrentsFromUrlsCtx(ctx context.Context, urls []string, opti
 		return nil, ErrNoTorrentURLProvided
 	}
 
-	options["urls"] = strings.Join(urls, "\n")
+	form := make(map[string]string, len(options)+1)
+	maps.Copy(form, options)
+	form["urls"] = strings.Join(urls, "\n")
 
-	resp, err := c.postCtx(ctx, "torrents/add", options)
+	resp, err := c.postCtx(ctx, "torrents/add", form)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not add torrents; urls: %v", urls)
 	}
@@ -2520,7 +2525,9 @@ func (c *Client) SetTorrentSuperSeedingCtx(ctx context.Context, hashes []string,
 }
 
 // ShareLimitOptions defines share limit settings for torrents.
-// ShareLimitAction and ShareLimitsMode were added in webapi 2.12.
+// ShareLimitAction requires WebAPI 2.12. ShareLimitsMode requires WebAPI 2.15.3.
+// From WebAPI 2.15.2, time limits use signed 32-bit minutes, at most 2147483647.
+// Use -2 for the global limit and -1 for no limit.
 //
 // ShareLimitAction and ShareLimitsMode must be Qt meta enum key names as used
 // by the WebUI (see Utils::String::toEnum in qBittorrent). Numeric strings such
@@ -2535,11 +2542,11 @@ type ShareLimitOptions struct {
 
 // Share limit action names for SetTorrentShareLimit (BitTorrent::ShareLimitAction).
 const (
-	ShareLimitActionDefault             = "Default"
-	ShareLimitActionStop                = "Stop"
-	ShareLimitActionRemove              = "Remove"
-	ShareLimitActionEnableSuperSeeding  = "EnableSuperSeeding"
-	ShareLimitActionRemoveWithContent   = "RemoveWithContent"
+	ShareLimitActionDefault            = "Default"
+	ShareLimitActionStop               = "Stop"
+	ShareLimitActionRemove             = "Remove"
+	ShareLimitActionEnableSuperSeeding = "EnableSuperSeeding"
+	ShareLimitActionRemoveWithContent  = "RemoveWithContent"
 )
 
 // Share limits mode names for SetTorrentShareLimit (BitTorrent::ShareLimitsMode).

--- a/rss.go
+++ b/rss.go
@@ -70,18 +70,44 @@ type RSSRuleTorrentParams struct {
 	DownloadPath             string   `json:"download_path,omitempty"`
 	ContentLayout            string   `json:"content_layout,omitempty"`
 	OperatingMode            string   `json:"operating_mode,omitempty"`
-	SkipChecking             bool     `json:"skip_checking,omitempty"`
+	SkipChecking             bool     `json:"skip_checking"`
 	UploadLimit              int      `json:"upload_limit,omitempty"`
 	DownloadLimit            int      `json:"download_limit,omitempty"`
 	SeedingTimeLimit         int      `json:"seeding_time_limit,omitempty"`
 	InactiveSeedingTimeLimit int      `json:"inactive_seeding_time_limit,omitempty"`
 	ShareLimitAction         string   `json:"share_limit_action,omitempty"`
+	ShareLimitsMode          string   `json:"share_limits_mode,omitempty"`
 	RatioLimit               float64  `json:"ratio_limit,omitempty"`
 	Stopped                  *bool    `json:"stopped,omitempty"`
 	StopCondition            string   `json:"stop_condition,omitempty"`
 	UseAutoTMM               *bool    `json:"use_auto_tmm,omitempty"`
 	UseDownloadPath          *bool    `json:"use_download_path,omitempty"`
 	AddToQueueTop            *bool    `json:"add_to_top_of_queue,omitempty"`
+}
+
+// UnmarshalJSON gives seed_mode precedence over the legacy skip_checking field.
+func (p *RSSRuleTorrentParams) UnmarshalJSON(data []byte) error {
+	type params RSSRuleTorrentParams
+	wire := struct {
+		*params
+		SeedMode *bool `json:"seed_mode"`
+	}{params: (*params)(p)}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	if wire.SeedMode != nil {
+		p.SkipChecking = *wire.SeedMode
+	}
+	return nil
+}
+
+// MarshalJSON preserves false and sends matching aliases for old and new servers.
+func (p RSSRuleTorrentParams) MarshalJSON() ([]byte, error) {
+	type params RSSRuleTorrentParams
+	return json.Marshal(struct {
+		params
+		SeedMode bool `json:"seed_mode"`
+	}{params: params(p), SeedMode: p.SkipChecking})
 }
 
 // RSSRules represents the response from rss/rules endpoint.


### PR DESCRIPTION
Keeps add requests, RSS rules, creation dates, and preferences compatible with qBittorrent 5.3 and older servers.

Closes #137.

Compared the API parsers and serializers at qBittorrent revisions `55d169a94` and `release-5.2.2`. CI covers the HTTP regression tests.

## AI disclosure

OpenAI Codex implemented and reviewed this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional torrent backup and mail notification preferences.
  * Added support for torrent creation timestamps provided as legacy dates or Unix timestamps.
  * Added RSS rule support for share-limit modes and seed-mode settings.
  * Improved compatibility with legacy and current torrent option names.

* **Bug Fixes**
  * Prevented upload option maps from being modified unexpectedly.
  * Ensured RSS settings preserve explicit false values during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->